### PR TITLE
Add active and archived Opportunity lifecycle

### DIFF
--- a/apps/desktop/electron/cmm-ipc.test.ts
+++ b/apps/desktop/electron/cmm-ipc.test.ts
@@ -34,6 +34,12 @@ describe('registerCmmIpcHandlers', () => {
     const opportunityService: OpportunityService = {
       createOpportunity: vi.fn(async () => opportunity),
       listActiveOpportunities: vi.fn(async () => [opportunity]),
+      listArchivedOpportunities: vi.fn(async () => [
+        {
+          ...opportunity,
+          archivedAt: '2026-05-01T09:10:00.000Z',
+        },
+      ]),
       openOpportunity: vi.fn(async () => ({
         opportunity: {
           ...opportunity,
@@ -44,6 +50,22 @@ describe('registerCmmIpcHandlers', () => {
           requirements: [],
         },
       })),
+      openArchivedOpportunity: vi.fn(async () => ({
+        opportunity: {
+          ...opportunity,
+          archivedAt: '2026-05-01T09:10:00.000Z',
+        },
+        baseCapabilityMatrix: {
+          opportunityId: opportunity.id,
+          requirements: [],
+        },
+      })),
+      archiveOpportunity: vi.fn(async () => ({
+        ...opportunity,
+        archivedAt: '2026-05-01T09:10:00.000Z',
+      })),
+      restoreArchivedOpportunity: vi.fn(async () => opportunity),
+      hardDeleteArchivedOpportunity: vi.fn(async () => undefined),
     };
 
     registerCmmIpcHandlers(ipcMain, { opportunityService });
@@ -52,7 +74,12 @@ describe('registerCmmIpcHandlers', () => {
       [
         cmmIpcContracts.createOpportunity.channel,
         cmmIpcContracts.listActiveOpportunities.channel,
+        cmmIpcContracts.listArchivedOpportunities.channel,
         cmmIpcContracts.openOpportunity.channel,
+        cmmIpcContracts.openArchivedOpportunity.channel,
+        cmmIpcContracts.archiveOpportunity.channel,
+        cmmIpcContracts.restoreArchivedOpportunity.channel,
+        cmmIpcContracts.hardDeleteArchivedOpportunity.channel,
       ].sort(),
     );
 
@@ -66,6 +93,25 @@ describe('registerCmmIpcHandlers', () => {
     );
     expect(opportunityService.createOpportunity).toHaveBeenCalledWith({
       name: 'Arctic Radar Upgrade',
+    });
+
+    const archiveHandler = ipcMain.handlers.get(cmmIpcContracts.archiveOpportunity.channel);
+    await expect(archiveHandler?.({}, { opportunityId: 'opportunity-1' })).resolves.toEqual({
+      ...opportunity,
+      archivedAt: '2026-05-01T09:10:00.000Z',
+    });
+    expect(opportunityService.archiveOpportunity).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
+    });
+
+    const hardDeleteHandler = ipcMain.handlers.get(
+      cmmIpcContracts.hardDeleteArchivedOpportunity.channel,
+    );
+    await expect(hardDeleteHandler?.({}, { opportunityId: 'opportunity-1' })).resolves.toEqual({
+      opportunityId: 'opportunity-1',
+    });
+    expect(opportunityService.hardDeleteArchivedOpportunity).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
     });
   });
 });

--- a/apps/desktop/electron/cmm-ipc.ts
+++ b/apps/desktop/electron/cmm-ipc.ts
@@ -38,7 +38,29 @@ export const registerCmmIpcHandlers = (
   registerValidatedHandler(ipcMain, cmmIpcContracts.listActiveOpportunities, () =>
     opportunityService.listActiveOpportunities(),
   );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.listArchivedOpportunities, () =>
+    opportunityService.listArchivedOpportunities(),
+  );
   registerValidatedHandler(ipcMain, cmmIpcContracts.openOpportunity, (input) =>
     opportunityService.openOpportunity(input),
+  );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.openArchivedOpportunity, (input) =>
+    opportunityService.openArchivedOpportunity(input),
+  );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.archiveOpportunity, (input) =>
+    opportunityService.archiveOpportunity(input),
+  );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.restoreArchivedOpportunity, (input) =>
+    opportunityService.restoreArchivedOpportunity(input),
+  );
+  registerValidatedHandler(
+    ipcMain,
+    cmmIpcContracts.hardDeleteArchivedOpportunity,
+    async (input) => {
+      await opportunityService.hardDeleteArchivedOpportunity(input);
+      return {
+        opportunityId: input.opportunityId,
+      };
+    },
   );
 };

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -2,6 +2,7 @@ import {
   type CreateOpportunityIpcInput,
   cmmIpcContracts,
   type OpenOpportunityIpcInput,
+  type OpportunityLifecycleIpcInput,
 } from '@cmm/contracts';
 import { contextBridge, ipcRenderer } from 'electron';
 
@@ -10,6 +11,16 @@ contextBridge.exposeInMainWorld('cmmApi', {
     ipcRenderer.invoke(cmmIpcContracts.createOpportunity.channel, input),
   listActiveOpportunities: () =>
     ipcRenderer.invoke(cmmIpcContracts.listActiveOpportunities.channel),
+  listArchivedOpportunities: () =>
+    ipcRenderer.invoke(cmmIpcContracts.listArchivedOpportunities.channel),
   openOpportunity: (input: OpenOpportunityIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.openOpportunity.channel, input),
+  openArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.openArchivedOpportunity.channel, input),
+  archiveOpportunity: (input: OpportunityLifecycleIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.archiveOpportunity.channel, input),
+  restoreArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.restoreArchivedOpportunity.channel, input),
+  hardDeleteArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.hardDeleteArchivedOpportunity.channel, input),
 });

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,0 +1,203 @@
+import type { OpportunityDto } from '@cmm/contracts';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+const activeOpportunity: OpportunityDto = {
+  id: 'opportunity-active',
+  name: 'Arctic Radar Upgrade',
+  solicitationNumber: 'RFP-2026-17',
+  issuingAgency: 'Naval Systems Command',
+  description: null,
+  createdAt: '2026-05-01T09:00:00.000Z',
+  updatedAt: '2026-05-01T09:00:00.000Z',
+  lastOpenedAt: null,
+  archivedAt: null,
+};
+
+const archivedOpportunity: OpportunityDto = {
+  ...activeOpportunity,
+  id: 'opportunity-archived',
+  name: 'Archived Radar Upgrade',
+  updatedAt: '2026-05-01T09:10:00.000Z',
+  archivedAt: '2026-05-01T09:10:00.000Z',
+};
+
+const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
+  const api: Window['cmmApi'] = {
+    createOpportunity: vi.fn(),
+    listActiveOpportunities: vi.fn(async () => [activeOpportunity]),
+    listArchivedOpportunities: vi.fn(async () => [archivedOpportunity]),
+    openOpportunity: vi.fn(async ({ opportunityId }) => ({
+      opportunity: {
+        ...activeOpportunity,
+        id: opportunityId,
+      },
+      baseCapabilityMatrix: {
+        opportunityId,
+        requirements: [],
+      },
+    })),
+    openArchivedOpportunity: vi.fn(async ({ opportunityId }) => ({
+      opportunity: {
+        ...archivedOpportunity,
+        id: opportunityId,
+      },
+      baseCapabilityMatrix: {
+        opportunityId,
+        requirements: [],
+      },
+    })),
+    archiveOpportunity: vi.fn(),
+    restoreArchivedOpportunity: vi.fn(),
+    hardDeleteArchivedOpportunity: vi.fn(),
+    ...overrides,
+  };
+
+  Object.defineProperty(window, 'cmmApi', {
+    configurable: true,
+    value: api,
+  });
+
+  return api;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('App', () => {
+  it('defaults to active Opportunities and shows archived Opportunities separately', async () => {
+    installCmmApi();
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    expect(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' })).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Open Archived Radar Upgrade' }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Archived' }));
+
+    expect(
+      await screen.findByRole('button', { name: 'Open Archived Radar Upgrade' }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Open Arctic Radar Upgrade' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('archives active Opportunities into a read-only archived workspace', async () => {
+    const archivedFromActive = {
+      ...activeOpportunity,
+      updatedAt: '2026-05-01T09:10:00.000Z',
+      archivedAt: '2026-05-01T09:10:00.000Z',
+    };
+    let active: OpportunityDto[] = [activeOpportunity];
+    let archived: OpportunityDto[] = [];
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => active),
+      listArchivedOpportunities: vi.fn(async () => archived),
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix: {
+          opportunityId: activeOpportunity.id,
+          requirements: [],
+        },
+      })),
+      archiveOpportunity: vi.fn(async () => {
+        active = [];
+        archived = [archivedFromActive];
+        return archivedFromActive;
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(await screen.findByRole('button', { name: 'Archive Opportunity' }));
+
+    expect(api.archiveOpportunity).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+    });
+    expect(await screen.findByText('Read-only')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Restore Opportunity' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Hard delete Opportunity' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Open Arctic Radar Upgrade' })).toBeVisible();
+  });
+
+  it('restores archived Opportunities to active work', async () => {
+    const restoredOpportunity = {
+      ...archivedOpportunity,
+      archivedAt: null,
+      updatedAt: '2026-05-01T09:20:00.000Z',
+    };
+    let active: OpportunityDto[] = [];
+    let archived: OpportunityDto[] = [archivedOpportunity];
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => active),
+      listArchivedOpportunities: vi.fn(async () => archived),
+      restoreArchivedOpportunity: vi.fn(async () => {
+        active = [restoredOpportunity];
+        archived = [];
+        return restoredOpportunity;
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Archived' }));
+    await user.click(await screen.findByRole('button', { name: 'Open Archived Radar Upgrade' }));
+    expect(await screen.findByText('Read-only')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Restore Opportunity' }));
+
+    expect(api.restoreArchivedOpportunity).toHaveBeenCalledWith({
+      opportunityId: archivedOpportunity.id,
+    });
+    expect(screen.queryByText('Read-only')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Active' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Archive Opportunity' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Open Archived Radar Upgrade' })).toBeVisible();
+  });
+
+  it('requires confirmation before hard-deleting an archived Opportunity', async () => {
+    let archived = [archivedOpportunity];
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => []),
+      listArchivedOpportunities: vi.fn(async () => archived),
+      hardDeleteArchivedOpportunity: vi.fn(async () => {
+        archived = [];
+        return {
+          opportunityId: archivedOpportunity.id,
+        };
+      }),
+    });
+    const confirm = vi.spyOn(window, 'confirm');
+    confirm.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Archived' }));
+    await user.click(await screen.findByRole('button', { name: 'Open Archived Radar Upgrade' }));
+    await user.click(screen.getByRole('button', { name: 'Hard delete Opportunity' }));
+
+    expect(api.hardDeleteArchivedOpportunity).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Open Archived Radar Upgrade' })).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Hard delete Opportunity' }));
+
+    expect(api.hardDeleteArchivedOpportunity).toHaveBeenCalledWith({
+      opportunityId: archivedOpportunity.id,
+    });
+    expect(await screen.findByText('No archived Opportunities')).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Hard delete Opportunity' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -14,6 +14,12 @@ type OpportunityFormState = {
   description: string;
 };
 
+type OpportunityListMode = 'active' | 'archived';
+
+type OpenedOpportunityState = OpenOpportunityIpcOutput & {
+  lifecycle: OpportunityListMode;
+};
+
 const emptyForm: OpportunityFormState = {
   name: '',
   solicitationNumber: '',
@@ -43,13 +49,20 @@ const formatOpenedAt = (opportunity: OpportunityDto): string => {
 
 function App(): React.JSX.Element {
   const [opportunities, setOpportunities] = useState<OpportunityDto[]>([]);
-  const [openedOpportunity, setOpenedOpportunity] = useState<OpenOpportunityIpcOutput | null>(null);
+  const [archivedOpportunities, setArchivedOpportunities] = useState<OpportunityDto[]>([]);
+  const [listMode, setListMode] = useState<OpportunityListMode>('active');
+  const [openedOpportunity, setOpenedOpportunity] = useState<OpenedOpportunityState | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
   const [error, setError] = useState<string | null>(null);
 
   const refreshOpportunities = useCallback(async () => {
-    setOpportunities(await window.cmmApi.listActiveOpportunities());
+    const [active, archived] = await Promise.all([
+      window.cmmApi.listActiveOpportunities(),
+      window.cmmApi.listArchivedOpportunities(),
+    ]);
+    setOpportunities(active);
+    setArchivedOpportunities(archived);
   }, []);
 
   useEffect(() => {
@@ -62,8 +75,14 @@ function App(): React.JSX.Element {
 
   const openOpportunity = async (opportunityId: string) => {
     setError(null);
-    const opened = await window.cmmApi.openOpportunity({ opportunityId });
-    setOpenedOpportunity(opened);
+    const opened =
+      listMode === 'active'
+        ? await window.cmmApi.openOpportunity({ opportunityId })
+        : await window.cmmApi.openArchivedOpportunity({ opportunityId });
+    setOpenedOpportunity({
+      ...opened,
+      lifecycle: listMode,
+    });
     await refreshOpportunities();
   };
 
@@ -83,6 +102,86 @@ function App(): React.JSX.Element {
     }
   };
 
+  const archiveOpenedOpportunity = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle !== 'active') {
+      return;
+    }
+
+    setError(null);
+    try {
+      const archived = await window.cmmApi.archiveOpportunity({
+        opportunityId: openedOpportunity.opportunity.id,
+      });
+      await refreshOpportunities();
+      setListMode('archived');
+      setOpenedOpportunity({
+        ...openedOpportunity,
+        opportunity: archived,
+        lifecycle: 'archived',
+      });
+    } catch (unknownError) {
+      setError(
+        unknownError instanceof Error ? unknownError.message : 'Unable to archive Opportunity.',
+      );
+    }
+  };
+
+  const restoreOpenedOpportunity = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle !== 'archived') {
+      return;
+    }
+
+    setError(null);
+    try {
+      const restored = await window.cmmApi.restoreArchivedOpportunity({
+        opportunityId: openedOpportunity.opportunity.id,
+      });
+      await refreshOpportunities();
+      setListMode('active');
+      setOpenedOpportunity({
+        ...openedOpportunity,
+        opportunity: restored,
+        lifecycle: 'active',
+      });
+    } catch (unknownError) {
+      setError(
+        unknownError instanceof Error ? unknownError.message : 'Unable to restore Opportunity.',
+      );
+    }
+  };
+
+  const hardDeleteOpenedOpportunity = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle !== 'archived') {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      'Hard delete this archived Opportunity? This cannot be undone.',
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    setError(null);
+    try {
+      await window.cmmApi.hardDeleteArchivedOpportunity({
+        opportunityId: openedOpportunity.opportunity.id,
+      });
+      await refreshOpportunities();
+      setListMode('archived');
+      setOpenedOpportunity(null);
+    } catch (unknownError) {
+      setError(
+        unknownError instanceof Error ? unknownError.message : 'Unable to hard delete Opportunity.',
+      );
+    }
+  };
+
+  const visibleOpportunities = listMode === 'active' ? opportunities : archivedOpportunities;
+  const emptyListLabel =
+    listMode === 'active' ? 'No Opportunities yet' : 'No archived Opportunities';
+  const isArchivedWorkspace = openedOpportunity?.lifecycle === 'archived';
+
   return (
     <div className="app-shell">
       <aside className="opportunity-sidebar" aria-label="Opportunity navigation">
@@ -92,6 +191,25 @@ function App(): React.JSX.Element {
             New Opportunity
           </Button>
         </div>
+
+        <nav className="opportunity-list-tabs" aria-label="Opportunity list">
+          <Button
+            aria-pressed={listMode === 'active'}
+            className={listMode === 'active' ? 'list-tab list-tab-active' : 'list-tab'}
+            variant="ghost"
+            onClick={() => setListMode('active')}
+          >
+            Active
+          </Button>
+          <Button
+            aria-pressed={listMode === 'archived'}
+            className={listMode === 'archived' ? 'list-tab list-tab-active' : 'list-tab'}
+            variant="ghost"
+            onClick={() => setListMode('archived')}
+          >
+            Archived
+          </Button>
+        </nav>
 
         {isCreating ? (
           <form className="opportunity-form" onSubmit={createOpportunity}>
@@ -147,14 +265,15 @@ function App(): React.JSX.Element {
         {error ? <p className="error-message">{error}</p> : null}
 
         <div className="opportunity-list">
-          {opportunities.length === 0 ? (
-            <p className="empty-state">No Opportunities yet</p>
+          {visibleOpportunities.length === 0 ? (
+            <p className="empty-state">{emptyListLabel}</p>
           ) : (
-            opportunities.map((opportunity) => (
+            visibleOpportunities.map((opportunity) => (
               <button
                 aria-label={`Open ${opportunity.name}`}
                 className={
-                  openedOpportunity?.opportunity.id === opportunity.id
+                  openedOpportunity?.opportunity.id === opportunity.id &&
+                  openedOpportunity.lifecycle === listMode
                     ? 'opportunity-row opportunity-row-active'
                     : 'opportunity-row'
                 }
@@ -178,13 +297,41 @@ function App(): React.JSX.Element {
                 <p className="eyebrow">{openedOpportunity.opportunity.name}</p>
                 <h2>Base Capability Matrix</h2>
               </div>
-              {openedOpportunity.opportunity.solicitationNumber ? (
-                <span className="solicitation-number">
-                  {openedOpportunity.opportunity.solicitationNumber}
-                </span>
-              ) : null}
+              <div className="workspace-actions">
+                {isArchivedWorkspace ? (
+                  <>
+                    <span className="read-only-badge">Read-only</span>
+                    <Button variant="secondary" onClick={() => void restoreOpenedOpportunity()}>
+                      Restore Opportunity
+                    </Button>
+                    <Button
+                      className="destructive-action"
+                      variant="secondary"
+                      onClick={() => void hardDeleteOpenedOpportunity()}
+                    >
+                      Hard delete Opportunity
+                    </Button>
+                  </>
+                ) : (
+                  <Button variant="secondary" onClick={() => void archiveOpenedOpportunity()}>
+                    Archive Opportunity
+                  </Button>
+                )}
+                {openedOpportunity.opportunity.solicitationNumber ? (
+                  <span className="solicitation-number">
+                    {openedOpportunity.opportunity.solicitationNumber}
+                  </span>
+                ) : null}
+              </div>
             </header>
-            <section className="matrix-empty" aria-label="Base Capability Matrix workspace">
+            <section
+              className="matrix-empty"
+              aria-label={
+                isArchivedWorkspace
+                  ? 'Read-only Base Capability Matrix workspace'
+                  : 'Base Capability Matrix workspace'
+              }
+            >
               <p>No requirements yet.</p>
             </section>
           </>

--- a/apps/desktop/src/electron-api.d.ts
+++ b/apps/desktop/src/electron-api.d.ts
@@ -1,14 +1,23 @@
 import type {
   CreateOpportunityIpcInput,
+  HardDeleteArchivedOpportunityIpcOutput,
   OpenOpportunityIpcInput,
   OpenOpportunityIpcOutput,
+  OpportunityLifecycleIpcInput,
   OpportunityDto,
 } from '@cmm/contracts';
 
 export interface CmmApi {
   createOpportunity(input: CreateOpportunityIpcInput): Promise<OpportunityDto>;
   listActiveOpportunities(): Promise<OpportunityDto[]>;
+  listArchivedOpportunities(): Promise<OpportunityDto[]>;
   openOpportunity(input: OpenOpportunityIpcInput): Promise<OpenOpportunityIpcOutput>;
+  openArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpenOpportunityIpcOutput>;
+  archiveOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
+  restoreArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
+  hardDeleteArchivedOpportunity(
+    input: OpportunityLifecycleIpcInput,
+  ): Promise<HardDeleteArchivedOpportunityIpcOutput>;
 }
 
 declare global {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -65,6 +65,26 @@ textarea {
   padding: 18px 0;
 }
 
+.opportunity-list-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  border: 1px solid #d9ded6;
+  border-radius: 6px;
+  background: #eef1eb;
+  padding: 4px;
+}
+
+.list-tab {
+  min-width: 0;
+}
+
+.list-tab-active {
+  background: #ffffff;
+  color: #1c2228;
+  box-shadow: 0 1px 2px rgba(28, 34, 40, 0.08);
+}
+
 .cmm-field {
   display: grid;
   gap: 6px;
@@ -192,6 +212,15 @@ textarea {
   padding-bottom: 24px;
 }
 
+.workspace-actions {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .workspace-header h2,
 .workspace-empty h2 {
   font-size: 28px;
@@ -212,6 +241,21 @@ textarea {
   padding: 6px 10px;
   font-size: 13px;
   font-weight: 700;
+}
+
+.read-only-badge {
+  border: 1px solid #b8c2bc;
+  border-radius: 999px;
+  background: #e8ede9;
+  color: #405047;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.destructive-action {
+  border-color: #d9a7a1;
+  color: #8d1d15;
 }
 
 .matrix-empty,

--- a/apps/desktop/tests/e2e/desktop.spec.ts
+++ b/apps/desktop/tests/e2e/desktop.spec.ts
@@ -76,9 +76,17 @@ test.describe
       await expect(
         firstSession.page.getByRole('button', { name: 'Open Maritime Logistics Support' }),
       ).toBeVisible();
+
+      await firstSession.page.getByRole('button', { name: 'Archive Opportunity' }).click();
+      await expect(firstSession.page.getByText('Read-only')).toBeVisible();
+      await expect(
+        firstSession.page.getByRole('button', { name: 'Restore Opportunity' }),
+      ).toBeVisible();
       await firstSession.electronApp.close();
 
       const secondSession = await launchDesktopApp(dataDir);
+      await expect(secondSession.page.getByText('No Opportunities yet')).toBeVisible();
+      await secondSession.page.getByRole('button', { name: 'Archived' }).click();
       await expect(
         secondSession.page.getByRole('button', { name: 'Open Maritime Logistics Support' }),
       ).toBeVisible();
@@ -90,6 +98,31 @@ test.describe
         secondSession.page.getByRole('heading', { name: 'Base Capability Matrix' }),
       ).toBeVisible();
       await expect(secondSession.page.getByText('No requirements yet.')).toBeVisible();
+      await expect(secondSession.page.getByText('Read-only')).toBeVisible();
+
+      await secondSession.page.getByRole('button', { name: 'Restore Opportunity' }).click();
+      await expect(secondSession.page.getByRole('button', { name: 'Active' })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      await expect(
+        secondSession.page.getByRole('button', { name: 'Archive Opportunity' }),
+      ).toBeVisible();
+
+      await secondSession.page.getByRole('button', { name: 'Archive Opportunity' }).click();
+      await expect(secondSession.page.getByText('Read-only')).toBeVisible();
+
+      secondSession.page.once('dialog', (dialog) => {
+        void dialog.accept();
+      });
+      await secondSession.page.getByRole('button', { name: 'Hard delete Opportunity' }).click();
+      await expect(secondSession.page.getByText('No archived Opportunities')).toBeVisible();
       await secondSession.electronApp.close();
+
+      const thirdSession = await launchDesktopApp(dataDir);
+      await expect(thirdSession.page.getByText('No Opportunities yet')).toBeVisible();
+      await thirdSession.page.getByRole('button', { name: 'Archived' }).click();
+      await expect(thirdSession.page.getByText('No archived Opportunities')).toBeVisible();
+      await thirdSession.electronApp.close();
     });
   });

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -18,14 +18,34 @@ export type IdGenerator = {
 export type OpportunityRepository = {
   saveOpportunity(opportunity: Opportunity): Promise<void>;
   listActiveOpportunities(): Promise<Opportunity[]>;
+  listArchivedOpportunities(): Promise<Opportunity[]>;
   findActiveOpportunityById(opportunityId: OpportunityId): Promise<Opportunity | null>;
+  findArchivedOpportunityById(opportunityId: OpportunityId): Promise<Opportunity | null>;
   markOpportunityOpened(
     opportunityId: OpportunityId,
     lastOpenedAt: IsoDateTime,
   ): Promise<Opportunity>;
+  archiveOpportunity(opportunityId: OpportunityId, archivedAt: IsoDateTime): Promise<Opportunity>;
+  restoreArchivedOpportunity(
+    opportunityId: OpportunityId,
+    restoredAt: IsoDateTime,
+  ): Promise<Opportunity>;
+  hardDeleteArchivedOpportunity(opportunityId: OpportunityId): Promise<void>;
 };
 
 export type OpenOpportunityInput = {
+  opportunityId: OpportunityId;
+};
+
+export type ArchiveOpportunityInput = {
+  opportunityId: OpportunityId;
+};
+
+export type RestoreArchivedOpportunityInput = {
+  opportunityId: OpportunityId;
+};
+
+export type HardDeleteArchivedOpportunityInput = {
   opportunityId: OpportunityId;
 };
 
@@ -37,7 +57,12 @@ export type OpenOpportunityResult = {
 export type OpportunityService = {
   createOpportunity(input: CreateOpportunityInput): Promise<Opportunity>;
   listActiveOpportunities(): Promise<Opportunity[]>;
+  listArchivedOpportunities(): Promise<Opportunity[]>;
   openOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
+  openArchivedOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
+  archiveOpportunity(input: ArchiveOpportunityInput): Promise<Opportunity>;
+  restoreArchivedOpportunity(input: RestoreArchivedOpportunityInput): Promise<Opportunity>;
+  hardDeleteArchivedOpportunity(input: HardDeleteArchivedOpportunityInput): Promise<void>;
 };
 
 export type CreateOpportunityServiceOptions = {
@@ -88,6 +113,10 @@ export const createOpportunityService = ({
     return repository.listActiveOpportunities();
   },
 
+  listArchivedOpportunities() {
+    return repository.listArchivedOpportunities();
+  },
+
   async openOpportunity(input) {
     const existing = await repository.findActiveOpportunityById(input.opportunityId);
     if (!existing) {
@@ -102,5 +131,47 @@ export const createOpportunityService = ({
         requirements: [],
       },
     };
+  },
+
+  async openArchivedOpportunity(input) {
+    const opportunity = await repository.findArchivedOpportunityById(input.opportunityId);
+    if (!opportunity) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    return {
+      opportunity,
+      baseCapabilityMatrix: {
+        opportunityId: opportunity.id,
+        requirements: [],
+      },
+    };
+  },
+
+  async archiveOpportunity(input) {
+    const existing = await repository.findActiveOpportunityById(input.opportunityId);
+    if (!existing) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    return repository.archiveOpportunity(input.opportunityId, clock.now());
+  },
+
+  async restoreArchivedOpportunity(input) {
+    const existing = await repository.findArchivedOpportunityById(input.opportunityId);
+    if (!existing) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    return repository.restoreArchivedOpportunity(input.opportunityId, clock.now());
+  },
+
+  async hardDeleteArchivedOpportunity(input) {
+    const existing = await repository.findArchivedOpportunityById(input.opportunityId);
+    if (!existing) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    await repository.hardDeleteArchivedOpportunity(input.opportunityId);
   },
 });

--- a/packages/application/src/opportunity-service.test.ts
+++ b/packages/application/src/opportunity-service.test.ts
@@ -15,9 +15,23 @@ class InMemoryOpportunityRepository implements OpportunityRepository {
     );
   }
 
+  async listArchivedOpportunities(): Promise<Opportunity[]> {
+    return Array.from(this.opportunities.values()).filter(
+      (opportunity) => opportunity.archivedAt !== null,
+    );
+  }
+
   async findActiveOpportunityById(opportunityId: OpportunityId): Promise<Opportunity | null> {
     const opportunity = this.opportunities.get(opportunityId);
     if (!opportunity || opportunity.archivedAt !== null) {
+      return null;
+    }
+    return opportunity;
+  }
+
+  async findArchivedOpportunityById(opportunityId: OpportunityId): Promise<Opportunity | null> {
+    const opportunity = this.opportunities.get(opportunityId);
+    if (!opportunity || opportunity.archivedAt === null) {
       return null;
     }
     return opportunity;
@@ -34,6 +48,48 @@ class InMemoryOpportunityRepository implements OpportunityRepository {
     const updated = { ...opportunity, lastOpenedAt };
     this.opportunities.set(opportunityId, updated);
     return updated;
+  }
+
+  async archiveOpportunity(
+    opportunityId: OpportunityId,
+    archivedAt: IsoDateTime,
+  ): Promise<Opportunity> {
+    const opportunity = this.opportunities.get(opportunityId);
+    if (!opportunity || opportunity.archivedAt !== null) {
+      throw new Error('Opportunity not found.');
+    }
+    const updated = {
+      ...opportunity,
+      updatedAt: archivedAt,
+      archivedAt,
+    };
+    this.opportunities.set(opportunityId, updated);
+    return updated;
+  }
+
+  async restoreArchivedOpportunity(
+    opportunityId: OpportunityId,
+    restoredAt: IsoDateTime,
+  ): Promise<Opportunity> {
+    const opportunity = this.opportunities.get(opportunityId);
+    if (!opportunity || opportunity.archivedAt === null) {
+      throw new Error('Opportunity not found.');
+    }
+    const updated = {
+      ...opportunity,
+      updatedAt: restoredAt,
+      archivedAt: null,
+    };
+    this.opportunities.set(opportunityId, updated);
+    return updated;
+  }
+
+  async hardDeleteArchivedOpportunity(opportunityId: OpportunityId): Promise<void> {
+    const opportunity = this.opportunities.get(opportunityId);
+    if (!opportunity || opportunity.archivedAt === null) {
+      throw new Error('Opportunity not found.');
+    }
+    this.opportunities.delete(opportunityId);
   }
 }
 
@@ -93,5 +149,127 @@ describe('OpportunityService', () => {
       },
     });
     await expect(service.listActiveOpportunities()).resolves.toEqual([opened.opportunity]);
+  });
+
+  it('archives an active Opportunity into the archived Opportunity list', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:10:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({
+      name: 'Arctic Radar Upgrade',
+    });
+
+    const archived = await service.archiveOpportunity({ opportunityId: created.id });
+
+    expect(archived).toEqual({
+      ...created,
+      updatedAt: '2026-05-01T09:10:00.000Z',
+      archivedAt: '2026-05-01T09:10:00.000Z',
+    });
+    await expect(service.listActiveOpportunities()).resolves.toEqual([]);
+    await expect(service.listArchivedOpportunities()).resolves.toEqual([archived]);
+  });
+
+  it('restores an archived Opportunity with prior data intact', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock([
+        '2026-05-01T09:00:00.000Z',
+        '2026-05-01T09:05:00.000Z',
+        '2026-05-01T09:10:00.000Z',
+        '2026-05-01T09:15:00.000Z',
+      ]),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({
+      name: 'Arctic Radar Upgrade',
+      solicitationNumber: 'RFP-2026-17',
+      issuingAgency: 'Naval Systems Command',
+      description: 'Sensor modernization pursuit',
+    });
+    const opened = await service.openOpportunity({ opportunityId: created.id });
+    const archived = await service.archiveOpportunity({ opportunityId: created.id });
+
+    const restored = await service.restoreArchivedOpportunity({ opportunityId: archived.id });
+
+    expect(restored).toEqual({
+      ...opened.opportunity,
+      updatedAt: '2026-05-01T09:15:00.000Z',
+      archivedAt: null,
+    });
+    await expect(service.listActiveOpportunities()).resolves.toEqual([restored]);
+    await expect(service.listArchivedOpportunities()).resolves.toEqual([]);
+  });
+
+  it('opens an archived Opportunity for read-only inspection without marking it opened', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock([
+        '2026-05-01T09:00:00.000Z',
+        '2026-05-01T09:05:00.000Z',
+        '2026-05-01T09:10:00.000Z',
+      ]),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    const opened = await service.openOpportunity({ opportunityId: created.id });
+    const archived = await service.archiveOpportunity({ opportunityId: created.id });
+
+    await expect(service.openOpportunity({ opportunityId: archived.id })).rejects.toThrow(
+      'Opportunity not found.',
+    );
+    await expect(service.openArchivedOpportunity({ opportunityId: archived.id })).resolves.toEqual({
+      opportunity: {
+        ...archived,
+        lastOpenedAt: opened.opportunity.lastOpenedAt,
+      },
+      baseCapabilityMatrix: {
+        opportunityId: 'opportunity-1',
+        requirements: [],
+      },
+    });
+  });
+
+  it('hard-deletes an archived Opportunity', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:10:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    const archived = await service.archiveOpportunity({ opportunityId: created.id });
+
+    await expect(
+      service.hardDeleteArchivedOpportunity({ opportunityId: archived.id }),
+    ).resolves.toBeUndefined();
+
+    await expect(service.listActiveOpportunities()).resolves.toEqual([]);
+    await expect(service.listArchivedOpportunities()).resolves.toEqual([]);
+  });
+
+  it('rejects hard delete for an active Opportunity', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+
+    await expect(
+      service.hardDeleteArchivedOpportunity({ opportunityId: created.id }),
+    ).rejects.toThrow('Opportunity not found.');
+    await expect(service.listActiveOpportunities()).resolves.toEqual([created]);
   });
 });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -22,7 +22,7 @@ const createOpportunityInputSchema = z.object({
   description: nullableTextSchema.optional(),
 });
 
-const openOpportunityInputSchema = z.object({
+const opportunityIdInputSchema = z.object({
   opportunityId: z
     .string()
     .refine((value) => value.trim().length > 0, 'Opportunity ID is required.'),
@@ -38,10 +38,18 @@ const openOpportunityOutputSchema = z.object({
   baseCapabilityMatrix: emptyBaseCapabilityMatrixSchema,
 });
 
+const hardDeleteArchivedOpportunityOutputSchema = z.object({
+  opportunityId: z.string().min(1),
+});
+
 export type OpportunityDto = z.infer<typeof opportunitySchema>;
 export type CreateOpportunityIpcInput = z.infer<typeof createOpportunityInputSchema>;
-export type OpenOpportunityIpcInput = z.infer<typeof openOpportunityInputSchema>;
+export type OpenOpportunityIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type OpenOpportunityIpcOutput = z.infer<typeof openOpportunityOutputSchema>;
+export type OpportunityLifecycleIpcInput = z.infer<typeof opportunityIdInputSchema>;
+export type HardDeleteArchivedOpportunityIpcOutput = z.infer<
+  typeof hardDeleteArchivedOpportunityOutputSchema
+>;
 
 export type IpcContract<Input, Output> = {
   channel: string;
@@ -64,10 +72,35 @@ export const cmmIpcContracts = {
     inputSchema: z.undefined(),
     outputSchema: z.array(opportunitySchema),
   }),
+  listArchivedOpportunities: defineContract({
+    channel: 'cmm:opportunities:list-archived',
+    inputSchema: z.undefined(),
+    outputSchema: z.array(opportunitySchema),
+  }),
   openOpportunity: defineContract({
     channel: 'cmm:opportunities:open',
-    inputSchema: openOpportunityInputSchema,
+    inputSchema: opportunityIdInputSchema,
     outputSchema: openOpportunityOutputSchema,
+  }),
+  openArchivedOpportunity: defineContract({
+    channel: 'cmm:opportunities:open-archived',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: openOpportunityOutputSchema,
+  }),
+  archiveOpportunity: defineContract({
+    channel: 'cmm:opportunities:archive',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: opportunitySchema,
+  }),
+  restoreArchivedOpportunity: defineContract({
+    channel: 'cmm:opportunities:restore-archived',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: opportunitySchema,
+  }),
+  hardDeleteArchivedOpportunity: defineContract({
+    channel: 'cmm:opportunities:hard-delete-archived',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: hardDeleteArchivedOpportunityOutputSchema,
   }),
 };
 

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -17,7 +17,18 @@ describe('Opportunity IPC contracts', () => {
   it('validates create, list, and open Opportunity IPC payloads', () => {
     expect(cmmIpcContracts.createOpportunity.channel).toBe('cmm:opportunities:create');
     expect(cmmIpcContracts.listActiveOpportunities.channel).toBe('cmm:opportunities:list-active');
+    expect(cmmIpcContracts.listArchivedOpportunities.channel).toBe(
+      'cmm:opportunities:list-archived',
+    );
     expect(cmmIpcContracts.openOpportunity.channel).toBe('cmm:opportunities:open');
+    expect(cmmIpcContracts.openArchivedOpportunity.channel).toBe('cmm:opportunities:open-archived');
+    expect(cmmIpcContracts.archiveOpportunity.channel).toBe('cmm:opportunities:archive');
+    expect(cmmIpcContracts.restoreArchivedOpportunity.channel).toBe(
+      'cmm:opportunities:restore-archived',
+    );
+    expect(cmmIpcContracts.hardDeleteArchivedOpportunity.channel).toBe(
+      'cmm:opportunities:hard-delete-archived',
+    );
 
     expect(
       validateIpcInput(cmmIpcContracts.createOpportunity, {
@@ -34,9 +45,32 @@ describe('Opportunity IPC contracts', () => {
     expect(() => validateIpcInput(cmmIpcContracts.openOpportunity, { opportunityId: '' })).toThrow(
       'Opportunity ID is required.',
     );
+    expect(
+      validateIpcInput(cmmIpcContracts.archiveOpportunity, { opportunityId: 'opportunity-1' }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
+    });
+    expect(
+      validateIpcInput(cmmIpcContracts.restoreArchivedOpportunity, {
+        opportunityId: 'opportunity-1',
+      }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
+    });
+    expect(
+      validateIpcInput(cmmIpcContracts.hardDeleteArchivedOpportunity, {
+        opportunityId: 'opportunity-1',
+      }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
+    });
 
     expect(validateIpcInput(cmmIpcContracts.listActiveOpportunities, undefined)).toBeUndefined();
+    expect(validateIpcInput(cmmIpcContracts.listArchivedOpportunities, undefined)).toBeUndefined();
     expect(validateIpcOutput(cmmIpcContracts.listActiveOpportunities, [opportunity])).toEqual([
+      opportunity,
+    ]);
+    expect(validateIpcOutput(cmmIpcContracts.listArchivedOpportunities, [opportunity])).toEqual([
       opportunity,
     ]);
     expect(
@@ -53,6 +87,38 @@ describe('Opportunity IPC contracts', () => {
         opportunityId: 'opportunity-1',
         requirements: [],
       },
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.openArchivedOpportunity, {
+        opportunity: {
+          ...opportunity,
+          archivedAt: '2026-05-01T09:10:00.000Z',
+        },
+        baseCapabilityMatrix: {
+          opportunityId: 'opportunity-1',
+          requirements: [],
+        },
+      }),
+    ).toEqual({
+      opportunity: {
+        ...opportunity,
+        archivedAt: '2026-05-01T09:10:00.000Z',
+      },
+      baseCapabilityMatrix: {
+        opportunityId: 'opportunity-1',
+        requirements: [],
+      },
+    });
+    expect(validateIpcOutput(cmmIpcContracts.archiveOpportunity, opportunity)).toEqual(opportunity);
+    expect(validateIpcOutput(cmmIpcContracts.restoreArchivedOpportunity, opportunity)).toEqual(
+      opportunity,
+    );
+    expect(
+      validateIpcOutput(cmmIpcContracts.hardDeleteArchivedOpportunity, {
+        opportunityId: 'opportunity-1',
+      }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
     });
   });
 });

--- a/packages/persistence-sqlite/src/index.ts
+++ b/packages/persistence-sqlite/src/index.ts
@@ -162,10 +162,58 @@ export const createSqliteOpportunityRepository = (
     WHERE id = ? AND archived_at IS NULL
   `);
 
+  const listArchived = database.prepare(`
+    SELECT
+      id,
+      name,
+      solicitation_number,
+      issuing_agency,
+      description,
+      created_at,
+      updated_at,
+      last_opened_at,
+      archived_at
+    FROM opportunities
+    WHERE archived_at IS NOT NULL
+    ORDER BY archived_at DESC, updated_at DESC, created_at DESC
+  `);
+
+  const findArchivedById = database.prepare(`
+    SELECT
+      id,
+      name,
+      solicitation_number,
+      issuing_agency,
+      description,
+      created_at,
+      updated_at,
+      last_opened_at,
+      archived_at
+    FROM opportunities
+    WHERE id = ? AND archived_at IS NOT NULL
+  `);
+
   const markOpened = database.prepare(`
     UPDATE opportunities
     SET last_opened_at = ?
     WHERE id = ? AND archived_at IS NULL
+  `);
+
+  const archiveOpportunity = database.prepare(`
+    UPDATE opportunities
+    SET archived_at = ?, updated_at = ?
+    WHERE id = ? AND archived_at IS NULL
+  `);
+
+  const restoreArchivedOpportunity = database.prepare(`
+    UPDATE opportunities
+    SET archived_at = NULL, updated_at = ?
+    WHERE id = ? AND archived_at IS NOT NULL
+  `);
+
+  const hardDeleteArchivedOpportunity = database.prepare(`
+    DELETE FROM opportunities
+    WHERE id = ? AND archived_at IS NOT NULL
   `);
 
   return {
@@ -177,8 +225,17 @@ export const createSqliteOpportunityRepository = (
       return listActive.all().map((row) => toOpportunity(row as OpportunityRow));
     },
 
+    async listArchivedOpportunities() {
+      return listArchived.all().map((row) => toOpportunity(row as OpportunityRow));
+    },
+
     async findActiveOpportunityById(opportunityId: OpportunityId) {
       const row = findActiveById.get(opportunityId);
+      return row ? toOpportunity(row as OpportunityRow) : null;
+    },
+
+    async findArchivedOpportunityById(opportunityId: OpportunityId) {
+      const row = findArchivedById.get(opportunityId);
       return row ? toOpportunity(row as OpportunityRow) : null;
     },
 
@@ -189,6 +246,31 @@ export const createSqliteOpportunityRepository = (
         throw new Error('Opportunity not found.');
       }
       return toOpportunity(row as OpportunityRow);
+    },
+
+    async archiveOpportunity(opportunityId, archivedAt) {
+      archiveOpportunity.run(archivedAt, archivedAt, opportunityId);
+      const row = findArchivedById.get(opportunityId);
+      if (!row) {
+        throw new Error('Opportunity not found.');
+      }
+      return toOpportunity(row as OpportunityRow);
+    },
+
+    async restoreArchivedOpportunity(opportunityId, restoredAt) {
+      restoreArchivedOpportunity.run(restoredAt, opportunityId);
+      const row = findActiveById.get(opportunityId);
+      if (!row) {
+        throw new Error('Opportunity not found.');
+      }
+      return toOpportunity(row as OpportunityRow);
+    },
+
+    async hardDeleteArchivedOpportunity(opportunityId) {
+      const result = hardDeleteArchivedOpportunity.run(opportunityId);
+      if (result.changes === 0) {
+        throw new Error('Opportunity not found.');
+      }
     },
   };
 };

--- a/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
+++ b/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
@@ -63,4 +63,130 @@ describe('SQLite Opportunity repository', () => {
     ]);
     secondDatabase.close();
   });
+
+  it('persists archived Opportunities across database connections', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const firstDatabase = createCmmSqliteDatabase(databasePath);
+    const firstService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(firstDatabase),
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:10:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await firstService.createOpportunity({
+      name: 'Maritime Logistics Support',
+      solicitationNumber: 'MLS-26',
+      issuingAgency: 'Defense Logistics Agency',
+      description: 'Local-first pursuit workspace for consortium planning.',
+    });
+    const archived = await firstService.archiveOpportunity({ opportunityId: created.id });
+    firstDatabase.close();
+
+    const secondDatabase = createCmmSqliteDatabase(databasePath);
+    const secondService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(secondDatabase),
+      clock: createClock(['2026-05-01T10:00:00.000Z']),
+      ids: { next: () => 'unused' },
+    });
+
+    await expect(secondService.listActiveOpportunities()).resolves.toEqual([]);
+    await expect(secondService.listArchivedOpportunities()).resolves.toEqual([archived]);
+    secondDatabase.close();
+  });
+
+  it('persists restored Opportunities across database connections', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const firstDatabase = createCmmSqliteDatabase(databasePath);
+    const firstService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(firstDatabase),
+      clock: createClock([
+        '2026-05-01T09:00:00.000Z',
+        '2026-05-01T09:10:00.000Z',
+        '2026-05-01T09:20:00.000Z',
+      ]),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await firstService.createOpportunity({
+      name: 'Maritime Logistics Support',
+      solicitationNumber: 'MLS-26',
+      issuingAgency: 'Defense Logistics Agency',
+      description: 'Local-first pursuit workspace for consortium planning.',
+    });
+    await firstService.archiveOpportunity({ opportunityId: created.id });
+    const restored = await firstService.restoreArchivedOpportunity({ opportunityId: created.id });
+    firstDatabase.close();
+
+    const secondDatabase = createCmmSqliteDatabase(databasePath);
+    const secondService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(secondDatabase),
+      clock: createClock(['2026-05-01T10:00:00.000Z']),
+      ids: { next: () => 'unused' },
+    });
+
+    await expect(secondService.listActiveOpportunities()).resolves.toEqual([restored]);
+    await expect(secondService.listArchivedOpportunities()).resolves.toEqual([]);
+    secondDatabase.close();
+  });
+
+  it('removes hard-deleted archived Opportunities across database connections', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const firstDatabase = createCmmSqliteDatabase(databasePath);
+    const firstService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(firstDatabase),
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:10:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await firstService.createOpportunity({
+      name: 'Maritime Logistics Support',
+    });
+    await firstService.archiveOpportunity({ opportunityId: created.id });
+    await firstService.hardDeleteArchivedOpportunity({ opportunityId: created.id });
+    firstDatabase.close();
+
+    const secondDatabase = createCmmSqliteDatabase(databasePath);
+    const secondService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(secondDatabase),
+      clock: createClock(['2026-05-01T10:00:00.000Z']),
+      ids: { next: () => 'unused' },
+    });
+
+    await expect(secondService.listActiveOpportunities()).resolves.toEqual([]);
+    await expect(secondService.listArchivedOpportunities()).resolves.toEqual([]);
+    secondDatabase.close();
+  });
+
+  it('rejects hard delete for active Opportunities at the repository boundary', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const database = createCmmSqliteDatabase(databasePath);
+    const repository = createSqliteOpportunityRepository(database);
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({
+      name: 'Maritime Logistics Support',
+    });
+
+    await expect(repository.hardDeleteArchivedOpportunity(created.id)).rejects.toThrow(
+      'Opportunity not found.',
+    );
+    await expect(service.listActiveOpportunities()).resolves.toEqual([created]);
+    database.close();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds active/archived Opportunity lifecycle use cases across application service, SQLite repository, IPC contracts, preload, and renderer.
- Keeps active Opportunities as the default list, adds a separate archived list, and opens archived Opportunities in a read-only workspace.
- Supports archive, restore, and confirmed hard delete for archived Opportunities only.

Closes #7

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm test`

Note: `pnpm test` emitted non-failing Watchman recrawl warnings from Jest.