### PR TITLE
Add Base Capability Matrix editing

### DIFF
--- a/apps/desktop/electron/cmm-ipc.test.ts
+++ b/apps/desktop/electron/cmm-ipc.test.ts
@@ -28,6 +28,20 @@ const opportunity: Opportunity = {
   archivedAt: null,
 };
 
+const baseCapabilityMatrix = {
+  opportunityId: opportunity.id,
+  revision: 1,
+  requirements: [
+    {
+      id: 'requirement-1',
+      text: 'Provide secure hosting',
+      level: 1,
+      position: 0,
+      retiredAt: null,
+    },
+  ],
+};
+
 describe('registerCmmIpcHandlers', () => {
   it('registers validated Opportunity handlers without exposing raw IPC to the renderer', async () => {
     const ipcMain = new FakeIpcMain();
@@ -45,21 +59,16 @@ describe('registerCmmIpcHandlers', () => {
           ...opportunity,
           lastOpenedAt: '2026-05-01T09:05:00.000Z',
         },
-        baseCapabilityMatrix: {
-          opportunityId: opportunity.id,
-          requirements: [],
-        },
+        baseCapabilityMatrix,
       })),
       openArchivedOpportunity: vi.fn(async () => ({
         opportunity: {
           ...opportunity,
           archivedAt: '2026-05-01T09:10:00.000Z',
         },
-        baseCapabilityMatrix: {
-          opportunityId: opportunity.id,
-          requirements: [],
-        },
+        baseCapabilityMatrix,
       })),
+      saveBaseCapabilityMatrix: vi.fn(async () => baseCapabilityMatrix),
       archiveOpportunity: vi.fn(async () => ({
         ...opportunity,
         archivedAt: '2026-05-01T09:10:00.000Z',
@@ -77,6 +86,7 @@ describe('registerCmmIpcHandlers', () => {
         cmmIpcContracts.listArchivedOpportunities.channel,
         cmmIpcContracts.openOpportunity.channel,
         cmmIpcContracts.openArchivedOpportunity.channel,
+        cmmIpcContracts.saveBaseCapabilityMatrix.channel,
         cmmIpcContracts.archiveOpportunity.channel,
         cmmIpcContracts.restoreArchivedOpportunity.channel,
         cmmIpcContracts.hardDeleteArchivedOpportunity.channel,
@@ -103,6 +113,17 @@ describe('registerCmmIpcHandlers', () => {
     expect(opportunityService.archiveOpportunity).toHaveBeenCalledWith({
       opportunityId: 'opportunity-1',
     });
+
+    const saveMatrixHandler = ipcMain.handlers.get(
+      cmmIpcContracts.saveBaseCapabilityMatrix.channel,
+    );
+    await expect(
+      saveMatrixHandler?.({}, { ...baseCapabilityMatrix, requirements: [{ id: 'bad' }] }),
+    ).rejects.toThrow();
+    await expect(saveMatrixHandler?.({}, baseCapabilityMatrix)).resolves.toEqual(
+      baseCapabilityMatrix,
+    );
+    expect(opportunityService.saveBaseCapabilityMatrix).toHaveBeenCalledWith(baseCapabilityMatrix);
 
     const hardDeleteHandler = ipcMain.handlers.get(
       cmmIpcContracts.hardDeleteArchivedOpportunity.channel,

--- a/apps/desktop/electron/cmm-ipc.ts
+++ b/apps/desktop/electron/cmm-ipc.ts
@@ -47,6 +47,9 @@ export const registerCmmIpcHandlers = (
   registerValidatedHandler(ipcMain, cmmIpcContracts.openArchivedOpportunity, (input) =>
     opportunityService.openArchivedOpportunity(input),
   );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.saveBaseCapabilityMatrix, (input) =>
+    opportunityService.saveBaseCapabilityMatrix(input),
+  );
   registerValidatedHandler(ipcMain, cmmIpcContracts.archiveOpportunity, (input) =>
     opportunityService.archiveOpportunity(input),
   );

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -3,6 +3,7 @@ import {
   cmmIpcContracts,
   type OpenOpportunityIpcInput,
   type OpportunityLifecycleIpcInput,
+  type SaveBaseCapabilityMatrixIpcInput,
 } from '@cmm/contracts';
 import { contextBridge, ipcRenderer } from 'electron';
 
@@ -17,6 +18,8 @@ contextBridge.exposeInMainWorld('cmmApi', {
     ipcRenderer.invoke(cmmIpcContracts.openOpportunity.channel, input),
   openArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.openArchivedOpportunity.channel, input),
+  saveBaseCapabilityMatrix: (input: SaveBaseCapabilityMatrixIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.saveBaseCapabilityMatrix.channel, input),
   archiveOpportunity: (input: OpportunityLifecycleIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.archiveOpportunity.channel, input),
   restoreArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,4 +1,4 @@
-import type { OpportunityDto } from '@cmm/contracts';
+import type { BaseCapabilityMatrixDto, OpportunityDto } from '@cmm/contracts';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -24,6 +24,12 @@ const archivedOpportunity: OpportunityDto = {
   archivedAt: '2026-05-01T09:10:00.000Z',
 };
 
+const emptyBaseCapabilityMatrix = (opportunityId: string): BaseCapabilityMatrixDto => ({
+  opportunityId,
+  revision: 0,
+  requirements: [],
+});
+
 const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
   const api: Window['cmmApi'] = {
     createOpportunity: vi.fn(),
@@ -34,20 +40,18 @@ const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
         ...activeOpportunity,
         id: opportunityId,
       },
-      baseCapabilityMatrix: {
-        opportunityId,
-        requirements: [],
-      },
+      baseCapabilityMatrix: emptyBaseCapabilityMatrix(opportunityId),
     })),
     openArchivedOpportunity: vi.fn(async ({ opportunityId }) => ({
       opportunity: {
         ...archivedOpportunity,
         id: opportunityId,
       },
-      baseCapabilityMatrix: {
-        opportunityId,
-        requirements: [],
-      },
+      baseCapabilityMatrix: emptyBaseCapabilityMatrix(opportunityId),
+    })),
+    saveBaseCapabilityMatrix: vi.fn(async (matrix) => ({
+      ...matrix,
+      revision: matrix.revision + 1,
     })),
     archiveOpportunity: vi.fn(),
     restoreArchivedOpportunity: vi.fn(),
@@ -102,10 +106,7 @@ describe('App', () => {
       listArchivedOpportunities: vi.fn(async () => archived),
       openOpportunity: vi.fn(async () => ({
         opportunity: activeOpportunity,
-        baseCapabilityMatrix: {
-          opportunityId: activeOpportunity.id,
-          requirements: [],
-        },
+        baseCapabilityMatrix: emptyBaseCapabilityMatrix(activeOpportunity.id),
       })),
       archiveOpportunity: vi.fn(async () => {
         active = [];
@@ -163,6 +164,117 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Active' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByRole('button', { name: 'Archive Opportunity' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Open Archived Radar Upgrade' })).toBeVisible();
+  });
+
+  it('edits, retires, reveals, and saves active Base Capability Matrix Requirements', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+      ],
+    };
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID');
+    randomUUID.mockReturnValue('00000000-0000-4000-8000-000000000001');
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 2 text'));
+    await user.type(screen.getByLabelText('Requirement 2 text'), 'Operate 24/7 help desk');
+    await user.click(screen.getByRole('button', { name: 'Move Requirement 2 up' }));
+    await user.click(screen.getByRole('button', { name: 'Indent Requirement 2' }));
+    await user.click(screen.getByRole('button', { name: 'Retire Requirement 1.1' }));
+
+    expect(screen.queryByDisplayValue('Provide secure hosting')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show retired Requirements' }));
+
+    expect(screen.getByDisplayValue('Provide secure hosting')).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: 'Add Requirement' }));
+    await user.type(screen.getByLabelText('Requirement 2 text'), 'Train operators');
+    await user.click(screen.getByRole('button', { name: 'Save Matrix' }));
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-2',
+          text: 'Operate 24/7 help desk',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        expect.objectContaining({
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 2,
+          position: 1,
+        }),
+        {
+          id: '00000000-0000-4000-8000-000000000001',
+          text: 'Train operators',
+          level: 1,
+          position: 2,
+          retiredAt: null,
+        },
+      ],
+    });
+    expect(await screen.findByText('Saved')).toBeVisible();
+  });
+
+  it('loads archived Opportunity matrices in a read-only workspace', async () => {
+    installCmmApi({
+      openArchivedOpportunity: vi.fn(async () => ({
+        opportunity: archivedOpportunity,
+        baseCapabilityMatrix: {
+          opportunityId: archivedOpportunity.id,
+          revision: 1,
+          requirements: [
+            {
+              id: 'requirement-1',
+              text: 'Provide secure hosting',
+              level: 1,
+              position: 0,
+              retiredAt: null,
+            },
+          ],
+        },
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Archived' }));
+    await user.click(await screen.findByRole('button', { name: 'Open Archived Radar Upgrade' }));
+
+    expect(await screen.findByDisplayValue('Provide secure hosting')).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Add Requirement' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save Matrix' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retire Requirement 1' })).not.toBeInTheDocument();
   });
 
   it('requires confirmation before hard-deleting an archived Opportunity', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,7 +1,9 @@
 import type {
+  BaseCapabilityMatrixDto,
   CreateOpportunityIpcInput,
   OpenOpportunityIpcOutput,
   OpportunityDto,
+  RequirementDto,
 } from '@cmm/contracts';
 import { Button, Field, TextArea, TextInput } from '@cmm/ui';
 import type { FormEvent } from 'react';
@@ -20,11 +22,56 @@ type OpenedOpportunityState = OpenOpportunityIpcOutput & {
   lifecycle: OpportunityListMode;
 };
 
+type MatrixSaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error' | 'conflict';
+
+type NumberedRequirement = {
+  requirement: RequirementDto;
+  displayNumber: string;
+};
+
 const emptyForm: OpportunityFormState = {
   name: '',
   solicitationNumber: '',
   issuingAgency: '',
   description: '',
+};
+
+const orderRequirements = (requirements: RequirementDto[]): RequirementDto[] =>
+  [...requirements].sort((left, right) => left.position - right.position);
+
+const normalizeRequirementPositions = (requirements: RequirementDto[]): RequirementDto[] =>
+  requirements.map((requirement, position) => ({
+    ...requirement,
+    level: Math.max(1, requirement.level),
+    position,
+  }));
+
+const computeRequirementNumbers = (
+  requirements: RequirementDto[],
+  includeRetired: boolean,
+): NumberedRequirement[] => {
+  const counters: number[] = [];
+  return orderRequirements(requirements)
+    .filter((requirement) => includeRetired || requirement.retiredAt === null)
+    .map((requirement) => {
+      const level = Math.max(1, requirement.level);
+      counters.length = level;
+      counters[level - 1] = (counters[level - 1] ?? 0) + 1;
+      for (let index = 0; index < level - 1; index += 1) {
+        counters[index] = counters[index] ?? 1;
+      }
+      return {
+        requirement,
+        displayNumber: counters.slice(0, level).join('.'),
+      };
+    });
+};
+
+const createRequirementId = (): string => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `requirement-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 };
 
 const toCreateInput = (form: OpportunityFormState): CreateOpportunityIpcInput => ({
@@ -52,6 +99,8 @@ function App(): React.JSX.Element {
   const [archivedOpportunities, setArchivedOpportunities] = useState<OpportunityDto[]>([]);
   const [listMode, setListMode] = useState<OpportunityListMode>('active');
   const [openedOpportunity, setOpenedOpportunity] = useState<OpenedOpportunityState | null>(null);
+  const [showRetiredRequirements, setShowRetiredRequirements] = useState(false);
+  const [matrixSaveState, setMatrixSaveState] = useState<MatrixSaveState>('idle');
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
   const [error, setError] = useState<string | null>(null);
@@ -83,7 +132,172 @@ function App(): React.JSX.Element {
       ...opened,
       lifecycle: listMode,
     });
+    setShowRetiredRequirements(false);
+    setMatrixSaveState('idle');
     await refreshOpportunities();
+  };
+
+  const updateMatrixDraft = (
+    updater: (matrix: BaseCapabilityMatrixDto) => BaseCapabilityMatrixDto,
+  ) => {
+    if (isArchivedWorkspace) {
+      return;
+    }
+
+    setOpenedOpportunity((current) => {
+      if (!current || current.lifecycle === 'archived') {
+        return current;
+      }
+
+      const updatedMatrix = updater(current.baseCapabilityMatrix);
+      return {
+        ...current,
+        baseCapabilityMatrix: {
+          ...updatedMatrix,
+          requirements: normalizeRequirementPositions(updatedMatrix.requirements),
+        },
+      };
+    });
+    setMatrixSaveState('dirty');
+  };
+
+  const addRequirement = () => {
+    updateMatrixDraft((matrix) => ({
+      ...matrix,
+      requirements: [
+        ...orderRequirements(matrix.requirements),
+        {
+          id: createRequirementId(),
+          text: '',
+          level: 1,
+          position: matrix.requirements.length,
+          retiredAt: null,
+        },
+      ],
+    }));
+  };
+
+  const editRequirementText = (requirementId: string, text: string) => {
+    updateMatrixDraft((matrix) => ({
+      ...matrix,
+      requirements: matrix.requirements.map((requirement) =>
+        requirement.id === requirementId
+          ? {
+              ...requirement,
+              text,
+            }
+          : requirement,
+      ),
+    }));
+  };
+
+  const moveRequirement = (requirementId: string, direction: -1 | 1) => {
+    updateMatrixDraft((matrix) => {
+      const requirements = orderRequirements(matrix.requirements);
+      const currentIndex = requirements.findIndex(
+        (requirement) => requirement.id === requirementId,
+      );
+      const nextIndex = currentIndex + direction;
+      if (currentIndex === -1 || nextIndex < 0 || nextIndex >= requirements.length) {
+        return matrix;
+      }
+
+      const [moved] = requirements.splice(currentIndex, 1);
+      if (!moved) {
+        return matrix;
+      }
+
+      requirements.splice(nextIndex, 0, moved);
+      return {
+        ...matrix,
+        requirements,
+      };
+    });
+  };
+
+  const indentRequirement = (requirementId: string) => {
+    updateMatrixDraft((matrix) => {
+      const requirements = orderRequirements(matrix.requirements);
+      const currentIndex = requirements.findIndex(
+        (requirement) => requirement.id === requirementId,
+      );
+      const requirement = requirements[currentIndex];
+      const previousRequirement = requirements[currentIndex - 1];
+      if (!requirement || !previousRequirement) {
+        return matrix;
+      }
+
+      const nextLevel = Math.min(requirement.level + 1, previousRequirement.level + 1);
+      return {
+        ...matrix,
+        requirements: requirements.map((row) =>
+          row.id === requirementId
+            ? {
+                ...row,
+                level: nextLevel,
+              }
+            : row,
+        ),
+      };
+    });
+  };
+
+  const outdentRequirement = (requirementId: string) => {
+    updateMatrixDraft((matrix) => ({
+      ...matrix,
+      requirements: matrix.requirements.map((requirement) =>
+        requirement.id === requirementId
+          ? {
+              ...requirement,
+              level: Math.max(1, requirement.level - 1),
+            }
+          : requirement,
+      ),
+    }));
+  };
+
+  const retireRequirement = (requirementId: string) => {
+    updateMatrixDraft((matrix) => ({
+      ...matrix,
+      requirements: matrix.requirements.map((requirement) =>
+        requirement.id === requirementId
+          ? {
+              ...requirement,
+              retiredAt: new Date().toISOString(),
+            }
+          : requirement,
+      ),
+    }));
+  };
+
+  const saveMatrix = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
+      return;
+    }
+
+    setError(null);
+    setMatrixSaveState('saving');
+    try {
+      const saved = await window.cmmApi.saveBaseCapabilityMatrix(
+        openedOpportunity.baseCapabilityMatrix,
+      );
+      setOpenedOpportunity((current) =>
+        current
+          ? {
+              ...current,
+              baseCapabilityMatrix: saved,
+            }
+          : current,
+      );
+      setMatrixSaveState('saved');
+    } catch (unknownError) {
+      const message =
+        unknownError instanceof Error
+          ? unknownError.message
+          : 'Unable to save Base Capability Matrix.';
+      setError(message);
+      setMatrixSaveState(message.includes('changed since') ? 'conflict' : 'error');
+    }
   };
 
   const createOpportunity = async (event: FormEvent<HTMLFormElement>) => {
@@ -181,6 +395,28 @@ function App(): React.JSX.Element {
   const emptyListLabel =
     listMode === 'active' ? 'No Opportunities yet' : 'No archived Opportunities';
   const isArchivedWorkspace = openedOpportunity?.lifecycle === 'archived';
+  const numberedRequirements = openedOpportunity
+    ? computeRequirementNumbers(
+        openedOpportunity.baseCapabilityMatrix.requirements,
+        showRetiredRequirements,
+      )
+    : [];
+  const retiredRequirementCount =
+    openedOpportunity?.baseCapabilityMatrix.requirements.filter(
+      (requirement) => requirement.retiredAt !== null,
+    ).length ?? 0;
+  const matrixStatusLabel =
+    matrixSaveState === 'dirty'
+      ? 'Unsaved'
+      : matrixSaveState === 'saving'
+        ? 'Saving'
+        : matrixSaveState === 'saved'
+          ? 'Saved'
+          : matrixSaveState === 'conflict'
+            ? 'Conflict'
+            : matrixSaveState === 'error'
+              ? 'Error'
+              : '';
 
   return (
     <div className="app-shell">
@@ -325,14 +561,113 @@ function App(): React.JSX.Element {
               </div>
             </header>
             <section
-              className="matrix-empty"
+              className="matrix-workspace"
               aria-label={
                 isArchivedWorkspace
                   ? 'Read-only Base Capability Matrix workspace'
                   : 'Base Capability Matrix workspace'
               }
             >
-              <p>No requirements yet.</p>
+              {!isArchivedWorkspace ? (
+                <div className="matrix-toolbar">
+                  <Button variant="primary" onClick={addRequirement}>
+                    Add Requirement
+                  </Button>
+                  <Button
+                    disabled={matrixSaveState !== 'dirty'}
+                    variant="secondary"
+                    onClick={() => void saveMatrix()}
+                  >
+                    Save Matrix
+                  </Button>
+                  {retiredRequirementCount > 0 ? (
+                    <Button
+                      aria-pressed={showRetiredRequirements}
+                      variant="ghost"
+                      onClick={() => setShowRetiredRequirements((current) => !current)}
+                    >
+                      {showRetiredRequirements
+                        ? 'Hide retired Requirements'
+                        : 'Show retired Requirements'}
+                    </Button>
+                  ) : null}
+                  {matrixStatusLabel ? (
+                    <span className="matrix-save-status">{matrixStatusLabel}</span>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {numberedRequirements.length === 0 ? (
+                <p className="matrix-empty-message">No requirements yet.</p>
+              ) : (
+                <ol className="matrix-outline" aria-label="Requirements">
+                  {numberedRequirements.map(({ requirement, displayNumber }, index) => {
+                    const isRetired = requirement.retiredAt !== null;
+                    const isEditable = !isArchivedWorkspace && !isRetired;
+                    return (
+                      <li
+                        className={
+                          isRetired ? 'requirement-row requirement-row-retired' : 'requirement-row'
+                        }
+                        key={requirement.id}
+                        style={{ marginLeft: `${Math.max(0, requirement.level - 1) * 28}px` }}
+                      >
+                        <span className="requirement-number">{displayNumber}</span>
+                        <TextInput
+                          aria-label={`Requirement ${displayNumber} text`}
+                          className="requirement-text"
+                          disabled={!isEditable}
+                          value={requirement.text}
+                          onChange={(event) =>
+                            editRequirementText(requirement.id, event.target.value)
+                          }
+                        />
+                        {isEditable ? (
+                          <div className="requirement-actions">
+                            <Button
+                              aria-label={`Move Requirement ${displayNumber} up`}
+                              disabled={index === 0}
+                              variant="ghost"
+                              onClick={() => moveRequirement(requirement.id, -1)}
+                            >
+                              Up
+                            </Button>
+                            <Button
+                              aria-label={`Move Requirement ${displayNumber} down`}
+                              disabled={index === numberedRequirements.length - 1}
+                              variant="ghost"
+                              onClick={() => moveRequirement(requirement.id, 1)}
+                            >
+                              Down
+                            </Button>
+                            <Button
+                              aria-label={`Indent Requirement ${displayNumber}`}
+                              variant="ghost"
+                              onClick={() => indentRequirement(requirement.id)}
+                            >
+                              Indent
+                            </Button>
+                            <Button
+                              aria-label={`Outdent Requirement ${displayNumber}`}
+                              variant="ghost"
+                              onClick={() => outdentRequirement(requirement.id)}
+                            >
+                              Outdent
+                            </Button>
+                            <Button
+                              aria-label={`Retire Requirement ${displayNumber}`}
+                              variant="ghost"
+                              onClick={() => retireRequirement(requirement.id)}
+                            >
+                              Retire
+                            </Button>
+                          </div>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
             </section>
           </>
         ) : (

--- a/apps/desktop/src/electron-api.d.ts
+++ b/apps/desktop/src/electron-api.d.ts
@@ -1,10 +1,12 @@
 import type {
   CreateOpportunityIpcInput,
+  BaseCapabilityMatrixDto,
   HardDeleteArchivedOpportunityIpcOutput,
   OpenOpportunityIpcInput,
   OpenOpportunityIpcOutput,
   OpportunityLifecycleIpcInput,
   OpportunityDto,
+  SaveBaseCapabilityMatrixIpcInput,
 } from '@cmm/contracts';
 
 export interface CmmApi {
@@ -13,6 +15,9 @@ export interface CmmApi {
   listArchivedOpportunities(): Promise<OpportunityDto[]>;
   openOpportunity(input: OpenOpportunityIpcInput): Promise<OpenOpportunityIpcOutput>;
   openArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpenOpportunityIpcOutput>;
+  saveBaseCapabilityMatrix(
+    input: SaveBaseCapabilityMatrixIpcInput,
+  ): Promise<BaseCapabilityMatrixDto>;
   archiveOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   restoreArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   hardDeleteArchivedOpportunity(

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -258,26 +258,86 @@ textarea {
   color: #8d1d15;
 }
 
-.matrix-empty,
+.matrix-workspace,
 .workspace-empty {
   display: grid;
   min-height: 220px;
-  place-items: center;
   border: 1px dashed #b9c0b5;
   background: #ffffff;
   color: #65717b;
   padding: 32px;
-  text-align: center;
 }
 
 .workspace-empty {
   align-content: center;
   gap: 8px;
+  place-items: center;
+  text-align: center;
 }
 
 .workspace-empty p,
-.matrix-empty p {
+.matrix-empty-message {
   margin: 0;
+}
+
+.matrix-workspace {
+  align-content: start;
+  gap: 18px;
+}
+
+.matrix-empty-message {
+  color: #65717b;
+  text-align: center;
+}
+
+.matrix-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.matrix-save-status {
+  color: #45505a;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.matrix-outline {
+  display: grid;
+  gap: 8px;
+}
+
+.requirement-row {
+  display: grid;
+  grid-template-columns: minmax(44px, auto) minmax(180px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid #edf0eb;
+  padding: 8px 0;
+}
+
+.requirement-row-retired {
+  opacity: 0.68;
+}
+
+.requirement-number {
+  color: #45505a;
+  font-size: 13px;
+  font-weight: 800;
+  text-align: right;
+}
+
+.requirement-text:disabled {
+  background: #f3f4f1;
+  color: #45505a;
+}
+
+.requirement-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
 }
 
 @media (max-width: 820px) {

--- a/apps/desktop/tests/e2e/desktop.spec.ts
+++ b/apps/desktop/tests/e2e/desktop.spec.ts
@@ -73,6 +73,10 @@ test.describe
         firstSession.page.getByRole('heading', { name: 'Base Capability Matrix' }),
       ).toBeVisible();
       await expect(firstSession.page.getByText('No requirements yet.')).toBeVisible();
+      await firstSession.page.getByRole('button', { name: 'Add Requirement' }).click();
+      await firstSession.page.getByLabel('Requirement 1 text').fill('Provide secure hosting');
+      await firstSession.page.getByRole('button', { name: 'Save Matrix' }).click();
+      await expect(firstSession.page.getByText('Saved')).toBeVisible();
       await expect(
         firstSession.page.getByRole('button', { name: 'Open Maritime Logistics Support' }),
       ).toBeVisible();
@@ -97,7 +101,10 @@ test.describe
       await expect(
         secondSession.page.getByRole('heading', { name: 'Base Capability Matrix' }),
       ).toBeVisible();
-      await expect(secondSession.page.getByText('No requirements yet.')).toBeVisible();
+      await expect(secondSession.page.getByLabel('Requirement 1 text')).toHaveValue(
+        'Provide secure hosting',
+      );
+      await expect(secondSession.page.getByLabel('Requirement 1 text')).toBeDisabled();
       await expect(secondSession.page.getByText('Read-only')).toBeVisible();
 
       await secondSession.page.getByRole('button', { name: 'Restore Opportunity' }).click();

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -4,8 +4,13 @@ import type {
   IsoDateTime,
   Opportunity,
   OpportunityId,
+  Requirement,
 } from '@cmm/domain';
-import { normalizeOptionalText, normalizeRequiredText } from '@cmm/domain';
+import {
+  normalizeOptionalText,
+  normalizeRequiredText,
+  normalizeRequirementPositions,
+} from '@cmm/domain';
 
 export type Clock = {
   now(): IsoDateTime;
@@ -31,6 +36,8 @@ export type OpportunityRepository = {
     restoredAt: IsoDateTime,
   ): Promise<Opportunity>;
   hardDeleteArchivedOpportunity(opportunityId: OpportunityId): Promise<void>;
+  loadBaseCapabilityMatrix(opportunityId: OpportunityId): Promise<BaseCapabilityMatrix>;
+  saveBaseCapabilityMatrix(matrix: BaseCapabilityMatrix): Promise<BaseCapabilityMatrix>;
 };
 
 export type OpenOpportunityInput = {
@@ -49,6 +56,12 @@ export type HardDeleteArchivedOpportunityInput = {
   opportunityId: OpportunityId;
 };
 
+export type SaveBaseCapabilityMatrixInput = {
+  opportunityId: OpportunityId;
+  revision: number;
+  requirements: Requirement[];
+};
+
 export type OpenOpportunityResult = {
   opportunity: Opportunity;
   baseCapabilityMatrix: BaseCapabilityMatrix;
@@ -60,6 +73,7 @@ export type OpportunityService = {
   listArchivedOpportunities(): Promise<Opportunity[]>;
   openOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
   openArchivedOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
+  saveBaseCapabilityMatrix(input: SaveBaseCapabilityMatrixInput): Promise<BaseCapabilityMatrix>;
   archiveOpportunity(input: ArchiveOpportunityInput): Promise<Opportunity>;
   restoreArchivedOpportunity(input: RestoreArchivedOpportunityInput): Promise<Opportunity>;
   hardDeleteArchivedOpportunity(input: HardDeleteArchivedOpportunityInput): Promise<void>;
@@ -73,7 +87,10 @@ export type CreateOpportunityServiceOptions = {
 
 export class ApplicationError extends Error {
   constructor(
-    readonly code: 'opportunity.nameRequired' | 'opportunity.notFound',
+    readonly code:
+      | 'opportunity.nameRequired'
+      | 'opportunity.notFound'
+      | 'baseMatrix.revisionConflict',
     message: string,
   ) {
     super(message);
@@ -124,13 +141,8 @@ export const createOpportunityService = ({
     }
 
     const opportunity = await repository.markOpportunityOpened(input.opportunityId, clock.now());
-    return {
-      opportunity,
-      baseCapabilityMatrix: {
-        opportunityId: opportunity.id,
-        requirements: [],
-      },
-    };
+    const baseCapabilityMatrix = await repository.loadBaseCapabilityMatrix(opportunity.id);
+    return { opportunity, baseCapabilityMatrix };
   },
 
   async openArchivedOpportunity(input) {
@@ -139,13 +151,29 @@ export const createOpportunityService = ({
       throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
     }
 
-    return {
-      opportunity,
-      baseCapabilityMatrix: {
-        opportunityId: opportunity.id,
-        requirements: [],
-      },
-    };
+    const baseCapabilityMatrix = await repository.loadBaseCapabilityMatrix(opportunity.id);
+    return { opportunity, baseCapabilityMatrix };
+  },
+
+  async saveBaseCapabilityMatrix(input) {
+    const existing = await repository.findActiveOpportunityById(input.opportunityId);
+    if (!existing) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    const currentMatrix = await repository.loadBaseCapabilityMatrix(input.opportunityId);
+    if (currentMatrix.revision !== input.revision) {
+      throw new ApplicationError(
+        'baseMatrix.revisionConflict',
+        'Base Capability Matrix has changed since it was opened.',
+      );
+    }
+
+    return repository.saveBaseCapabilityMatrix({
+      opportunityId: input.opportunityId,
+      revision: input.revision,
+      requirements: normalizeRequirementPositions(input.requirements),
+    });
   },
 
   async archiveOpportunity(input) {

--- a/packages/application/src/opportunity-service.test.ts
+++ b/packages/application/src/opportunity-service.test.ts
@@ -1,12 +1,18 @@
-import type { IsoDateTime, Opportunity, OpportunityId } from '@cmm/domain';
+import type { BaseCapabilityMatrix, IsoDateTime, Opportunity, OpportunityId } from '@cmm/domain';
 import { describe, expect, it } from 'vitest';
 import { createOpportunityService, type OpportunityRepository } from './index';
 
 class InMemoryOpportunityRepository implements OpportunityRepository {
   readonly opportunities = new Map<OpportunityId, Opportunity>();
+  readonly matrices = new Map<OpportunityId, BaseCapabilityMatrix>();
 
   async saveOpportunity(opportunity: Opportunity): Promise<void> {
     this.opportunities.set(opportunity.id, opportunity);
+    this.matrices.set(opportunity.id, {
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [],
+    });
   }
 
   async listActiveOpportunities(): Promise<Opportunity[]> {
@@ -90,6 +96,28 @@ class InMemoryOpportunityRepository implements OpportunityRepository {
       throw new Error('Opportunity not found.');
     }
     this.opportunities.delete(opportunityId);
+    this.matrices.delete(opportunityId);
+  }
+
+  async loadBaseCapabilityMatrix(opportunityId: OpportunityId): Promise<BaseCapabilityMatrix> {
+    const matrix = this.matrices.get(opportunityId);
+    if (!matrix) {
+      throw new Error('Base Capability Matrix not found.');
+    }
+    return matrix;
+  }
+
+  async saveBaseCapabilityMatrix(matrix: BaseCapabilityMatrix): Promise<BaseCapabilityMatrix> {
+    const current = this.matrices.get(matrix.opportunityId);
+    if (!current) {
+      throw new Error('Base Capability Matrix not found.');
+    }
+    const saved = {
+      ...matrix,
+      revision: current.revision + 1,
+    };
+    this.matrices.set(matrix.opportunityId, saved);
+    return saved;
   }
 }
 
@@ -145,6 +173,7 @@ describe('OpportunityService', () => {
       },
       baseCapabilityMatrix: {
         opportunityId: 'opportunity-1',
+        revision: 0,
         requirements: [],
       },
     });
@@ -233,9 +262,129 @@ describe('OpportunityService', () => {
       },
       baseCapabilityMatrix: {
         opportunityId: 'opportunity-1',
+        revision: 0,
         requirements: [],
       },
     });
+  });
+
+  it('saves and reopens an active Opportunity Base Capability Matrix with stable Requirement IDs', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:05:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+
+    const saved = await service.saveBaseCapabilityMatrix({
+      opportunityId: created.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 3,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 2,
+          position: 8,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    expect(saved).toEqual({
+      opportunityId: created.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 2,
+          position: 1,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    const reopened = await service.openOpportunity({ opportunityId: created.id });
+
+    expect(reopened.baseCapabilityMatrix).toEqual(saved);
+  });
+
+  it('rejects stale Base Capability Matrix saves', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.saveBaseCapabilityMatrix({
+      opportunityId: created.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    await expect(
+      service.saveBaseCapabilityMatrix({
+        opportunityId: created.id,
+        revision: 0,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide secure hosting with stale revision',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: 'baseMatrix.revisionConflict',
+    });
+  });
+
+  it('rejects Base Capability Matrix saves for archived Opportunities', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-01T09:10:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.archiveOpportunity({ opportunityId: created.id });
+
+    await expect(
+      service.saveBaseCapabilityMatrix({
+        opportunityId: created.id,
+        revision: 0,
+        requirements: [],
+      }),
+    ).rejects.toThrow('Opportunity not found.');
   });
 
   it('hard-deletes an archived Opportunity', async () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,14 +28,23 @@ const opportunityIdInputSchema = z.object({
     .refine((value) => value.trim().length > 0, 'Opportunity ID is required.'),
 });
 
-const emptyBaseCapabilityMatrixSchema = z.object({
+const requirementSchema = z.object({
+  id: z.string().min(1),
+  text: z.string(),
+  level: z.number().int().min(1),
+  position: z.number().int().min(0),
+  retiredAt: isoDateTimeSchema.nullable(),
+});
+
+const baseCapabilityMatrixSchema = z.object({
   opportunityId: z.string().min(1),
-  requirements: z.array(z.never()),
+  revision: z.number().int().min(0),
+  requirements: z.array(requirementSchema),
 });
 
 const openOpportunityOutputSchema = z.object({
   opportunity: opportunitySchema,
-  baseCapabilityMatrix: emptyBaseCapabilityMatrixSchema,
+  baseCapabilityMatrix: baseCapabilityMatrixSchema,
 });
 
 const hardDeleteArchivedOpportunityOutputSchema = z.object({
@@ -43,10 +52,13 @@ const hardDeleteArchivedOpportunityOutputSchema = z.object({
 });
 
 export type OpportunityDto = z.infer<typeof opportunitySchema>;
+export type RequirementDto = z.infer<typeof requirementSchema>;
+export type BaseCapabilityMatrixDto = z.infer<typeof baseCapabilityMatrixSchema>;
 export type CreateOpportunityIpcInput = z.infer<typeof createOpportunityInputSchema>;
 export type OpenOpportunityIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type OpenOpportunityIpcOutput = z.infer<typeof openOpportunityOutputSchema>;
 export type OpportunityLifecycleIpcInput = z.infer<typeof opportunityIdInputSchema>;
+export type SaveBaseCapabilityMatrixIpcInput = z.infer<typeof baseCapabilityMatrixSchema>;
 export type HardDeleteArchivedOpportunityIpcOutput = z.infer<
   typeof hardDeleteArchivedOpportunityOutputSchema
 >;
@@ -86,6 +98,11 @@ export const cmmIpcContracts = {
     channel: 'cmm:opportunities:open-archived',
     inputSchema: opportunityIdInputSchema,
     outputSchema: openOpportunityOutputSchema,
+  }),
+  saveBaseCapabilityMatrix: defineContract({
+    channel: 'cmm:base-matrices:save',
+    inputSchema: baseCapabilityMatrixSchema,
+    outputSchema: baseCapabilityMatrixSchema,
   }),
   archiveOpportunity: defineContract({
     channel: 'cmm:opportunities:archive',

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -13,6 +13,27 @@ const opportunity = {
   archivedAt: null,
 };
 
+const baseCapabilityMatrix = {
+  opportunityId: 'opportunity-1',
+  revision: 1,
+  requirements: [
+    {
+      id: 'requirement-1',
+      text: 'Provide secure hosting',
+      level: 1,
+      position: 0,
+      retiredAt: null,
+    },
+    {
+      id: 'requirement-2',
+      text: 'Retired draft Requirement',
+      level: 2,
+      position: 1,
+      retiredAt: '2026-05-01T10:00:00.000Z',
+    },
+  ],
+};
+
 describe('Opportunity IPC contracts', () => {
   it('validates create, list, and open Opportunity IPC payloads', () => {
     expect(cmmIpcContracts.createOpportunity.channel).toBe('cmm:opportunities:create');
@@ -29,6 +50,7 @@ describe('Opportunity IPC contracts', () => {
     expect(cmmIpcContracts.hardDeleteArchivedOpportunity.channel).toBe(
       'cmm:opportunities:hard-delete-archived',
     );
+    expect(cmmIpcContracts.saveBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:save');
 
     expect(
       validateIpcInput(cmmIpcContracts.createOpportunity, {
@@ -76,17 +98,11 @@ describe('Opportunity IPC contracts', () => {
     expect(
       validateIpcOutput(cmmIpcContracts.openOpportunity, {
         opportunity,
-        baseCapabilityMatrix: {
-          opportunityId: 'opportunity-1',
-          requirements: [],
-        },
+        baseCapabilityMatrix,
       }),
     ).toEqual({
       opportunity,
-      baseCapabilityMatrix: {
-        opportunityId: 'opportunity-1',
-        requirements: [],
-      },
+      baseCapabilityMatrix,
     });
     expect(
       validateIpcOutput(cmmIpcContracts.openArchivedOpportunity, {
@@ -94,21 +110,32 @@ describe('Opportunity IPC contracts', () => {
           ...opportunity,
           archivedAt: '2026-05-01T09:10:00.000Z',
         },
-        baseCapabilityMatrix: {
-          opportunityId: 'opportunity-1',
-          requirements: [],
-        },
+        baseCapabilityMatrix,
       }),
     ).toEqual({
       opportunity: {
         ...opportunity,
         archivedAt: '2026-05-01T09:10:00.000Z',
       },
-      baseCapabilityMatrix: {
-        opportunityId: 'opportunity-1',
-        requirements: [],
-      },
+      baseCapabilityMatrix,
     });
+    expect(
+      validateIpcInput(cmmIpcContracts.saveBaseCapabilityMatrix, baseCapabilityMatrix),
+    ).toEqual(baseCapabilityMatrix);
+    expect(() =>
+      validateIpcInput(cmmIpcContracts.saveBaseCapabilityMatrix, {
+        ...baseCapabilityMatrix,
+        requirements: [
+          {
+            ...baseCapabilityMatrix.requirements[0],
+            level: 0,
+          },
+        ],
+      }),
+    ).toThrow();
+    expect(
+      validateIpcOutput(cmmIpcContracts.saveBaseCapabilityMatrix, baseCapabilityMatrix),
+    ).toEqual(baseCapabilityMatrix);
     expect(validateIpcOutput(cmmIpcContracts.archiveOpportunity, opportunity)).toEqual(opportunity);
     expect(validateIpcOutput(cmmIpcContracts.restoreArchivedOpportunity, opportunity)).toEqual(
       opportunity,

--- a/packages/domain/src/base-capability-matrix.test.ts
+++ b/packages/domain/src/base-capability-matrix.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeRequirementNumbers,
+  editRequirementText,
+  indentRequirement,
+  moveRequirement,
+  outdentRequirement,
+  type Requirement,
+  retireRequirement,
+} from './index';
+
+describe('Base Capability Matrix requirements', () => {
+  it('computes display numbers from active Requirement order and level', () => {
+    const requirements: Requirement[] = [
+      {
+        id: 'requirement-1',
+        text: 'Provide secure hosting',
+        level: 1,
+        position: 0,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-2',
+        text: 'Operate help desk',
+        level: 2,
+        position: 1,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-3',
+        text: 'Retired draft row',
+        level: 2,
+        position: 2,
+        retiredAt: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        id: 'requirement-4',
+        text: 'Train operators',
+        level: 1,
+        position: 3,
+        retiredAt: null,
+      },
+    ];
+
+    expect(computeRequirementNumbers(requirements)).toEqual([
+      {
+        requirement: requirements[0],
+        displayNumber: '1',
+      },
+      {
+        requirement: requirements[1],
+        displayNumber: '1.1',
+      },
+      {
+        requirement: requirements[3],
+        displayNumber: '2',
+      },
+    ]);
+  });
+
+  it('preserves Requirement identity across text, order, level, and retirement edits', () => {
+    const requirements: Requirement[] = [
+      {
+        id: 'requirement-1',
+        text: 'Provide secure hosting',
+        level: 1,
+        position: 0,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-2',
+        text: 'Operate help desk',
+        level: 1,
+        position: 1,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-3',
+        text: 'Train operators',
+        level: 1,
+        position: 2,
+        retiredAt: null,
+      },
+    ];
+
+    const edited = editRequirementText(requirements, 'requirement-2', 'Operate 24/7 help desk');
+    expect(edited[1]).toMatchObject({
+      id: 'requirement-2',
+      text: 'Operate 24/7 help desk',
+      position: 1,
+    });
+
+    const moved = moveRequirement(edited, 'requirement-3', 0);
+    expect(moved.map((requirement) => requirement.id)).toEqual([
+      'requirement-3',
+      'requirement-1',
+      'requirement-2',
+    ]);
+    expect(moved.map((requirement) => requirement.position)).toEqual([0, 1, 2]);
+
+    const indented = indentRequirement(moved, 'requirement-1');
+    expect(indented[1]).toMatchObject({
+      id: 'requirement-1',
+      level: 2,
+      position: 1,
+    });
+
+    const outdented = outdentRequirement(indented, 'requirement-1');
+    expect(outdented[1]).toMatchObject({
+      id: 'requirement-1',
+      level: 1,
+      position: 1,
+    });
+
+    const retired = retireRequirement(outdented, 'requirement-1', '2026-05-01T10:00:00.000Z');
+    expect(retired[1]).toMatchObject({
+      id: 'requirement-1',
+      level: 1,
+      position: 1,
+      retiredAt: '2026-05-01T10:00:00.000Z',
+    });
+  });
+});

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export type IsoDateTime = string;
 export type OpportunityId = string;
+export type RequirementId = string;
 
 export type Opportunity = {
   id: OpportunityId;
@@ -22,12 +23,191 @@ export type CreateOpportunityInput = {
 
 export type BaseCapabilityMatrix = {
   opportunityId: OpportunityId;
-  requirements: never[];
+  revision: number;
+  requirements: Requirement[];
 };
+
+export type Requirement = {
+  id: RequirementId;
+  text: string;
+  level: number;
+  position: number;
+  retiredAt: IsoDateTime | null;
+};
+
+export type RequirementNumber = {
+  requirement: Requirement;
+  displayNumber: string;
+};
+
+const orderRequirements = (requirements: Requirement[]): Requirement[] =>
+  [...requirements].sort((left, right) => left.position - right.position);
+
+const findRequirementIndex = (requirements: Requirement[], requirementId: RequirementId): number =>
+  requirements.findIndex((requirement) => requirement.id === requirementId);
+
+const findSubtreeEndIndex = (requirements: Requirement[], startIndex: number): number => {
+  const root = requirements[startIndex];
+  if (!root) {
+    return startIndex;
+  }
+
+  let endIndex = startIndex + 1;
+  while (endIndex < requirements.length && (requirements[endIndex]?.level ?? 1) > root.level) {
+    endIndex += 1;
+  }
+  return endIndex;
+};
+
+const assignRequirementPositions = (requirements: Requirement[]): Requirement[] =>
+  requirements.map((requirement, position) => ({
+    ...requirement,
+    level: Math.max(1, requirement.level),
+    position,
+  }));
 
 export const normalizeRequiredText = (value: string): string => value.trim();
 
 export const normalizeOptionalText = (value: string | null | undefined): string | null => {
   const normalized = value?.trim() ?? '';
   return normalized.length > 0 ? normalized : null;
+};
+
+export const computeRequirementNumbers = (requirements: Requirement[]): RequirementNumber[] => {
+  const counters: number[] = [];
+  return orderRequirements(requirements)
+    .filter((requirement) => requirement.retiredAt === null)
+    .map((requirement) => {
+      const level = Math.max(1, requirement.level);
+      counters.length = level;
+      counters[level - 1] = (counters[level - 1] ?? 0) + 1;
+
+      for (let index = 0; index < level - 1; index += 1) {
+        counters[index] = counters[index] ?? 1;
+      }
+
+      return {
+        requirement,
+        displayNumber: counters.slice(0, level).join('.'),
+      };
+    });
+};
+
+export const normalizeRequirementPositions = (requirements: Requirement[]): Requirement[] =>
+  assignRequirementPositions(orderRequirements(requirements));
+
+export const editRequirementText = (
+  requirements: Requirement[],
+  requirementId: RequirementId,
+  text: string,
+): Requirement[] =>
+  normalizeRequirementPositions(
+    requirements.map((requirement) =>
+      requirement.id === requirementId
+        ? {
+            ...requirement,
+            text,
+          }
+        : requirement,
+    ),
+  );
+
+export const moveRequirement = (
+  requirements: Requirement[],
+  requirementId: RequirementId,
+  targetPosition: number,
+): Requirement[] => {
+  const ordered = normalizeRequirementPositions(requirements);
+  const index = findRequirementIndex(ordered, requirementId);
+  if (index === -1) {
+    return ordered;
+  }
+
+  const [removed] = ordered.splice(index, 1);
+  if (!removed) {
+    return ordered;
+  }
+
+  const insertAt = Math.max(0, Math.min(targetPosition, ordered.length));
+  ordered.splice(insertAt, 0, removed);
+  return assignRequirementPositions(ordered);
+};
+
+export const indentRequirement = (
+  requirements: Requirement[],
+  requirementId: RequirementId,
+): Requirement[] => {
+  const ordered = normalizeRequirementPositions(requirements);
+  const index = findRequirementIndex(ordered, requirementId);
+  const target = ordered[index];
+  const previous = ordered[index - 1];
+  if (!target || !previous) {
+    return ordered;
+  }
+
+  const nextLevel = Math.min(target.level + 1, previous.level + 1);
+  const levelDelta = nextLevel - target.level;
+  if (levelDelta === 0) {
+    return ordered;
+  }
+
+  const subtreeEnd = findSubtreeEndIndex(ordered, index);
+  return normalizeRequirementPositions(
+    ordered.map((requirement, requirementIndex) =>
+      requirementIndex >= index && requirementIndex < subtreeEnd
+        ? {
+            ...requirement,
+            level: requirement.level + levelDelta,
+          }
+        : requirement,
+    ),
+  );
+};
+
+export const outdentRequirement = (
+  requirements: Requirement[],
+  requirementId: RequirementId,
+): Requirement[] => {
+  const ordered = normalizeRequirementPositions(requirements);
+  const index = findRequirementIndex(ordered, requirementId);
+  const target = ordered[index];
+  if (!target || target.level === 1) {
+    return ordered;
+  }
+
+  const subtreeEnd = findSubtreeEndIndex(ordered, index);
+  return normalizeRequirementPositions(
+    ordered.map((requirement, requirementIndex) =>
+      requirementIndex >= index && requirementIndex < subtreeEnd
+        ? {
+            ...requirement,
+            level: Math.max(1, requirement.level - 1),
+          }
+        : requirement,
+    ),
+  );
+};
+
+export const retireRequirement = (
+  requirements: Requirement[],
+  requirementId: RequirementId,
+  retiredAt: IsoDateTime,
+): Requirement[] => {
+  const ordered = normalizeRequirementPositions(requirements);
+  const index = findRequirementIndex(ordered, requirementId);
+  if (index === -1) {
+    return ordered;
+  }
+
+  const subtreeEnd = findSubtreeEndIndex(ordered, index);
+  return normalizeRequirementPositions(
+    ordered.map((requirement, requirementIndex) =>
+      requirementIndex >= index && requirementIndex < subtreeEnd
+        ? {
+            ...requirement,
+            retiredAt,
+          }
+        : requirement,
+    ),
+  );
 };

--- a/packages/persistence-sqlite/src/index.ts
+++ b/packages/persistence-sqlite/src/index.ts
@@ -1,5 +1,5 @@
 import type { OpportunityRepository } from '@cmm/application';
-import type { Opportunity, OpportunityId } from '@cmm/domain';
+import type { BaseCapabilityMatrix, Opportunity, OpportunityId, Requirement } from '@cmm/domain';
 import type { Database as SqliteDatabase } from 'better-sqlite3';
 import Database from 'better-sqlite3';
 
@@ -32,6 +32,36 @@ const migrations: Migration[] = [
         ON opportunities (archived_at, last_opened_at, updated_at, created_at);
     `,
   },
+  {
+    id: 2,
+    name: '0002_create_base_capability_matrices',
+    sql: `
+      CREATE TABLE base_capability_matrices (
+        opportunity_id TEXT PRIMARY KEY
+          REFERENCES opportunities(id) ON DELETE CASCADE,
+        revision INTEGER NOT NULL DEFAULT 0
+      );
+
+      INSERT INTO base_capability_matrices (opportunity_id, revision)
+      SELECT id, 0
+      FROM opportunities
+      WHERE id NOT IN (SELECT opportunity_id FROM base_capability_matrices);
+
+      CREATE TABLE requirements (
+        id TEXT PRIMARY KEY,
+        opportunity_id TEXT NOT NULL
+          REFERENCES base_capability_matrices(opportunity_id) ON DELETE CASCADE,
+        text TEXT NOT NULL,
+        level INTEGER NOT NULL CHECK (level >= 1),
+        position INTEGER NOT NULL CHECK (position >= 0),
+        retired_at TEXT,
+        UNIQUE (opportunity_id, position)
+      );
+
+      CREATE INDEX requirements_opportunity_order_idx
+        ON requirements (opportunity_id, position);
+    `,
+  },
 ];
 
 type MigrationRow = {
@@ -50,6 +80,20 @@ type OpportunityRow = {
   archived_at: string | null;
 };
 
+type BaseCapabilityMatrixRow = {
+  opportunity_id: string;
+  revision: number;
+};
+
+type RequirementRow = {
+  id: string;
+  opportunity_id: string;
+  text: string;
+  level: number;
+  position: number;
+  retired_at: string | null;
+};
+
 const toOpportunity = (row: OpportunityRow): Opportunity => ({
   id: row.id,
   name: row.name,
@@ -60,6 +104,14 @@ const toOpportunity = (row: OpportunityRow): Opportunity => ({
   updatedAt: row.updated_at,
   lastOpenedAt: row.last_opened_at,
   archivedAt: row.archived_at,
+});
+
+const toRequirement = (row: RequirementRow): Requirement => ({
+  id: row.id,
+  text: row.text,
+  level: row.level,
+  position: row.position,
+  retiredAt: row.retired_at,
 });
 
 export const runSqliteMigrations = (database: SqliteDatabase): void => {
@@ -216,9 +268,111 @@ export const createSqliteOpportunityRepository = (
     WHERE id = ? AND archived_at IS NOT NULL
   `);
 
+  const insertBaseCapabilityMatrix = database.prepare(`
+    INSERT INTO base_capability_matrices (opportunity_id, revision)
+    VALUES (?, 0)
+  `);
+
+  const findBaseCapabilityMatrix = database.prepare(`
+    SELECT opportunity_id, revision
+    FROM base_capability_matrices
+    WHERE opportunity_id = ?
+  `);
+
+  const listRequirements = database.prepare(`
+    SELECT
+      id,
+      opportunity_id,
+      text,
+      level,
+      position,
+      retired_at
+    FROM requirements
+    WHERE opportunity_id = ?
+    ORDER BY position ASC
+  `);
+
+  const updateBaseCapabilityMatrixRevision = database.prepare(`
+    UPDATE base_capability_matrices
+    SET revision = ?
+    WHERE opportunity_id = ? AND revision = ?
+  `);
+
+  const deleteRequirementsForOpportunity = database.prepare(`
+    DELETE FROM requirements
+    WHERE opportunity_id = ?
+  `);
+
+  const insertRequirement = database.prepare(`
+    INSERT INTO requirements (
+      id,
+      opportunity_id,
+      text,
+      level,
+      position,
+      retired_at
+    ) VALUES (
+      @id,
+      @opportunityId,
+      @text,
+      @level,
+      @position,
+      @retiredAt
+    )
+  `);
+
+  const loadMatrix = (opportunityId: OpportunityId): BaseCapabilityMatrix => {
+    const matrixRow = findBaseCapabilityMatrix.get(opportunityId) as
+      | BaseCapabilityMatrixRow
+      | undefined;
+    if (!matrixRow) {
+      throw new Error('Base Capability Matrix not found.');
+    }
+
+    return {
+      opportunityId: matrixRow.opportunity_id,
+      revision: matrixRow.revision,
+      requirements: listRequirements
+        .all(opportunityId)
+        .map((row) => toRequirement(row as RequirementRow)),
+    };
+  };
+
+  const saveOpportunityWithMatrix = database.transaction((opportunity: Opportunity) => {
+    insertOpportunity.run(opportunity);
+    insertBaseCapabilityMatrix.run(opportunity.id);
+  });
+
+  const saveMatrix = database.transaction((matrix: BaseCapabilityMatrix) => {
+    const current = loadMatrix(matrix.opportunityId);
+    const nextRevision = matrix.revision + 1;
+    const updateResult = updateBaseCapabilityMatrixRevision.run(
+      nextRevision,
+      matrix.opportunityId,
+      matrix.revision,
+    );
+    if (current.revision !== matrix.revision || updateResult.changes === 0) {
+      throw new Error('Base Capability Matrix revision conflict.');
+    }
+
+    deleteRequirementsForOpportunity.run(matrix.opportunityId);
+    for (const requirement of matrix.requirements) {
+      insertRequirement.run({
+        id: requirement.id,
+        opportunityId: matrix.opportunityId,
+        text: requirement.text,
+        level: requirement.level,
+        position: requirement.position,
+        retiredAt: requirement.retiredAt,
+      });
+    }
+
+    return loadMatrix(matrix.opportunityId);
+  });
+
   return {
     async saveOpportunity(opportunity) {
-      insertOpportunity.run(opportunity);
+      saveOpportunityWithMatrix(opportunity);
     },
 
     async listActiveOpportunities() {
@@ -271,6 +425,14 @@ export const createSqliteOpportunityRepository = (
       if (result.changes === 0) {
         throw new Error('Opportunity not found.');
       }
+    },
+
+    async loadBaseCapabilityMatrix(opportunityId) {
+      return loadMatrix(opportunityId);
+    },
+
+    async saveBaseCapabilityMatrix(matrix) {
+      return saveMatrix(matrix);
     },
   };
 };

--- a/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
+++ b/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
@@ -135,6 +135,60 @@ describe('SQLite Opportunity repository', () => {
     secondDatabase.close();
   });
 
+  it('persists Base Capability Matrix Requirements across database connections', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-base-matrix-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const firstDatabase = createCmmSqliteDatabase(databasePath);
+    const firstService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(firstDatabase),
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const created = await firstService.createOpportunity({
+      name: 'Maritime Logistics Support',
+    });
+    const saved = await firstService.saveBaseCapabilityMatrix({
+      opportunityId: created.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Retired draft Requirement',
+          level: 2,
+          position: 1,
+          retiredAt: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+    });
+    firstDatabase.close();
+
+    const secondDatabase = createCmmSqliteDatabase(databasePath);
+    const secondService = createOpportunityService({
+      repository: createSqliteOpportunityRepository(secondDatabase),
+      clock: createClock(['2026-05-01T10:00:00.000Z']),
+      ids: { next: () => 'unused' },
+    });
+
+    await expect(secondService.openOpportunity({ opportunityId: created.id })).resolves.toEqual({
+      opportunity: {
+        ...created,
+        lastOpenedAt: '2026-05-01T10:00:00.000Z',
+      },
+      baseCapabilityMatrix: saved,
+    });
+    secondDatabase.close();
+  });
+
   it('removes hard-deleted archived Opportunities across database connections', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
     tempDirs.push(dir);


### PR DESCRIPTION
## Summary

Adds the Issue #8 Base Capability Matrix vertical slice on top of the Issue 7 lifecycle branch.

This PR introduces persisted Requirements with stable identity, computed display numbering, active matrix editing, retired Requirement visibility, and read-only archived matrix loading.

Stacked on PR #28 (`issue-7-opportunity-lifecycle`).

Closes #8.

## Changes

- Add pure domain Requirement model and outline operations for numbering, text edits, reorder, indent, outdent, and retirement.
- Add application service load/save behavior with revision conflict checks and archived Opportunity save rejection.
- Add SQLite persistence for one Base Capability Matrix per Opportunity and retained retired Requirements.
- Add IPC contracts, preload API, and renderer typing for matrix save payloads.
- Add renderer workflow for active editing and archived read-only inspection.
- Extend desktop e2e coverage for save, archive, relaunch, and read-only matrix behavior.

## Validation

- `pnpm check`
- `pnpm test`
- Pre-commit hook: format, lint, check, typecheck
