### PR TITLE
Add keyboard Base Capability Matrix editing

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -245,6 +245,357 @@ describe('App', () => {
     expect(await screen.findByText('Saved')).toBeVisible();
   });
 
+  it('inserts a new active Requirement from Enter and focuses the new text field', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+      ],
+    };
+    const randomUUID = vi.spyOn(globalThis.crypto, 'randomUUID');
+    randomUUID.mockReturnValue('00000000-0000-4000-8000-000000000002');
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByLabelText('Requirement 1 text'));
+    await user.keyboard('{Enter}');
+
+    const insertedRequirement = await screen.findByLabelText('Requirement 2 text');
+    expect(insertedRequirement).toHaveFocus();
+    expect(insertedRequirement).toHaveValue('');
+    expect(screen.getByLabelText('Requirement 3 text')).toHaveValue('Operate help desk');
+
+    await user.click(screen.getByRole('button', { name: 'Save Matrix' }));
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: '00000000-0000-4000-8000-000000000002',
+          text: '',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 2,
+          retiredAt: null,
+        },
+      ],
+    });
+  });
+
+  it('indents a focused Requirement subtree with Tab and preserves its identity', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-3',
+          text: 'Staff first-line support',
+          level: 2,
+          position: 2,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-4',
+          text: 'Train operators',
+          level: 1,
+          position: 3,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByLabelText('Requirement 2 text'));
+    await user.keyboard('{Tab}');
+
+    const indentedRequirement = screen.getByLabelText('Requirement 1.1 text');
+    expect(indentedRequirement).toHaveFocus();
+    expect(indentedRequirement).toHaveValue('Operate help desk');
+    expect(screen.getByLabelText('Requirement 1.1.1 text')).toHaveValue('Staff first-line support');
+    expect(screen.getByLabelText('Requirement 2 text')).toHaveValue('Train operators');
+
+    await user.click(screen.getByRole('button', { name: 'Save Matrix' }));
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 2,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-3',
+          text: 'Staff first-line support',
+          level: 3,
+          position: 2,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-4',
+          text: 'Train operators',
+          level: 1,
+          position: 3,
+          retiredAt: null,
+        },
+      ],
+    });
+  });
+
+  it('outdents a focused Requirement subtree with Shift+Tab', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 2,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-3',
+          text: 'Staff first-line support',
+          level: 3,
+          position: 2,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-4',
+          text: 'Train operators',
+          level: 1,
+          position: 3,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByLabelText('Requirement 1.1 text'));
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+
+    const outdentedRequirement = screen.getByLabelText('Requirement 2 text');
+    expect(outdentedRequirement).toHaveFocus();
+    expect(outdentedRequirement).toHaveValue('Operate help desk');
+    expect(screen.getByLabelText('Requirement 2.1 text')).toHaveValue('Staff first-line support');
+    expect(screen.getByLabelText('Requirement 3 text')).toHaveValue('Train operators');
+
+    await user.click(screen.getByRole('button', { name: 'Save Matrix' }));
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-3',
+          text: 'Staff first-line support',
+          level: 2,
+          position: 2,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-4',
+          text: 'Train operators',
+          level: 1,
+          position: 3,
+          retiredAt: null,
+        },
+      ],
+    });
+  });
+
+  it('navigates between Requirement text fields without blocking normal text edits', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-2',
+          text: 'Operate help desk',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-3',
+          text: 'Train operators',
+          level: 1,
+          position: 2,
+          retiredAt: null,
+        },
+      ],
+    };
+    installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByLabelText('Requirement 1 text'));
+    await user.keyboard(' with FedRAMP');
+    await user.keyboard('{Backspace}');
+    await user.keyboard('P');
+
+    expect(screen.getByLabelText('Requirement 1 text')).toHaveValue(
+      'Provide secure hosting with FedRAMP',
+    );
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByLabelText('Requirement 2 text')).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByLabelText('Requirement 3 text')).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(screen.getByLabelText('Requirement 2 text')).toHaveFocus();
+
+    await user.keyboard('{Shift>}{ArrowUp}{/Shift}');
+    expect(screen.getByLabelText('Requirement 2 text')).toHaveFocus();
+  });
+
+  it('does not trap focus when a keyboard outline command is not valid', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByLabelText('Requirement 1 text'));
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+
+    expect(screen.getByRole('button', { name: 'Add Requirement' })).toHaveFocus();
+  });
+
   it('loads archived Opportunity matrices in a read-only workspace', async () => {
     installCmmApi({
       openArchivedOpportunity: vi.fn(async () => ({

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,7 +6,7 @@ import type {
   RequirementDto,
 } from '@cmm/contracts';
 import { Button, Field, TextArea, TextInput } from '@cmm/ui';
-import type { FormEvent } from 'react';
+import type { FormEvent, KeyboardEvent } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 
 type OpportunityFormState = {
@@ -38,6 +38,22 @@ const emptyForm: OpportunityFormState = {
 
 const orderRequirements = (requirements: RequirementDto[]): RequirementDto[] =>
   [...requirements].sort((left, right) => left.position - right.position);
+
+const findRequirementSubtreeEndIndex = (
+  requirements: RequirementDto[],
+  startIndex: number,
+): number => {
+  const root = requirements[startIndex];
+  if (!root) {
+    return startIndex;
+  }
+
+  let endIndex = startIndex + 1;
+  while (endIndex < requirements.length && (requirements[endIndex]?.level ?? 1) > root.level) {
+    endIndex += 1;
+  }
+  return endIndex;
+};
 
 const normalizeRequirementPositions = (requirements: RequirementDto[]): RequirementDto[] =>
   requirements.map((requirement, position) => ({
@@ -74,6 +90,9 @@ const createRequirementId = (): string => {
   return `requirement-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 };
 
+const requirementTextInputId = (requirementId: string): string =>
+  `requirement-text-${requirementId}`;
+
 const toCreateInput = (form: OpportunityFormState): CreateOpportunityIpcInput => ({
   name: form.name,
   solicitationNumber: form.solicitationNumber || null,
@@ -101,6 +120,7 @@ function App(): React.JSX.Element {
   const [openedOpportunity, setOpenedOpportunity] = useState<OpenedOpportunityState | null>(null);
   const [showRetiredRequirements, setShowRetiredRequirements] = useState(false);
   const [matrixSaveState, setMatrixSaveState] = useState<MatrixSaveState>('idle');
+  const [pendingRequirementFocusId, setPendingRequirementFocusId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
   const [error, setError] = useState<string | null>(null);
@@ -121,6 +141,22 @@ function App(): React.JSX.Element {
       );
     });
   }, [refreshOpportunities]);
+
+  useEffect(() => {
+    if (!pendingRequirementFocusId) {
+      return;
+    }
+
+    const input = document.getElementById(
+      requirementTextInputId(pendingRequirementFocusId),
+    ) as HTMLInputElement | null;
+    if (!input) {
+      return;
+    }
+
+    input.focus();
+    setPendingRequirementFocusId(null);
+  }, [pendingRequirementFocusId]);
 
   const openOpportunity = async (opportunityId: string) => {
     setError(null);
@@ -177,6 +213,47 @@ function App(): React.JSX.Element {
     }));
   };
 
+  const insertRequirementAfter = (requirementId: string) => {
+    if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
+      return;
+    }
+
+    const requirements = orderRequirements(openedOpportunity.baseCapabilityMatrix.requirements);
+    const currentIndex = requirements.findIndex((requirement) => requirement.id === requirementId);
+    const currentRequirement = requirements[currentIndex];
+    if (!currentRequirement || currentRequirement.retiredAt !== null) {
+      return;
+    }
+
+    const nextRequirementId = createRequirementId();
+    updateMatrixDraft((matrix) => {
+      const orderedRequirements = orderRequirements(matrix.requirements);
+      const insertIndex = orderedRequirements.findIndex(
+        (requirement) => requirement.id === requirementId,
+      );
+      const precedingRequirement = orderedRequirements[insertIndex];
+      if (!precedingRequirement || precedingRequirement.retiredAt !== null) {
+        return matrix;
+      }
+
+      return {
+        ...matrix,
+        requirements: [
+          ...orderedRequirements.slice(0, insertIndex + 1),
+          {
+            id: nextRequirementId,
+            text: '',
+            level: precedingRequirement.level,
+            position: insertIndex + 1,
+            retiredAt: null,
+          },
+          ...orderedRequirements.slice(insertIndex + 1),
+        ],
+      };
+    });
+    setPendingRequirementFocusId(nextRequirementId);
+  };
+
   const editRequirementText = (requirementId: string, text: string) => {
     updateMatrixDraft((matrix) => ({
       ...matrix,
@@ -228,13 +305,19 @@ function App(): React.JSX.Element {
       }
 
       const nextLevel = Math.min(requirement.level + 1, previousRequirement.level + 1);
+      const levelDelta = nextLevel - requirement.level;
+      if (levelDelta === 0) {
+        return matrix;
+      }
+
+      const subtreeEndIndex = findRequirementSubtreeEndIndex(requirements, currentIndex);
       return {
         ...matrix,
-        requirements: requirements.map((row) =>
-          row.id === requirementId
+        requirements: requirements.map((row, rowIndex) =>
+          rowIndex >= currentIndex && rowIndex < subtreeEndIndex
             ? {
                 ...row,
-                level: nextLevel,
+                level: row.level + levelDelta,
               }
             : row,
         ),
@@ -243,17 +326,29 @@ function App(): React.JSX.Element {
   };
 
   const outdentRequirement = (requirementId: string) => {
-    updateMatrixDraft((matrix) => ({
-      ...matrix,
-      requirements: matrix.requirements.map((requirement) =>
-        requirement.id === requirementId
-          ? {
-              ...requirement,
-              level: Math.max(1, requirement.level - 1),
-            }
-          : requirement,
-      ),
-    }));
+    updateMatrixDraft((matrix) => {
+      const requirements = orderRequirements(matrix.requirements);
+      const currentIndex = requirements.findIndex(
+        (requirement) => requirement.id === requirementId,
+      );
+      const requirement = requirements[currentIndex];
+      if (!requirement || requirement.level === 1) {
+        return matrix;
+      }
+
+      const subtreeEndIndex = findRequirementSubtreeEndIndex(requirements, currentIndex);
+      return {
+        ...matrix,
+        requirements: requirements.map((row, rowIndex) =>
+          rowIndex >= currentIndex && rowIndex < subtreeEndIndex
+            ? {
+                ...row,
+                level: Math.max(1, row.level - 1),
+              }
+            : row,
+        ),
+      };
+    });
   };
 
   const retireRequirement = (requirementId: string) => {
@@ -269,6 +364,86 @@ function App(): React.JSX.Element {
       ),
     }));
   };
+
+  const canIndentRequirement = (requirementId: string): boolean => {
+    if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
+      return false;
+    }
+
+    const requirements = orderRequirements(openedOpportunity.baseCapabilityMatrix.requirements);
+    const currentIndex = requirements.findIndex((requirement) => requirement.id === requirementId);
+    const requirement = requirements[currentIndex];
+    const previousRequirement = requirements[currentIndex - 1];
+    if (!requirement || !previousRequirement) {
+      return false;
+    }
+
+    return Math.min(requirement.level + 1, previousRequirement.level + 1) > requirement.level;
+  };
+
+  const canOutdentRequirement = (requirementId: string): boolean => {
+    if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
+      return false;
+    }
+
+    const requirement = openedOpportunity.baseCapabilityMatrix.requirements.find(
+      (candidate) => candidate.id === requirementId,
+    );
+    return (requirement?.level ?? 1) > 1;
+  };
+
+  const handleRequirementTextKeyDown =
+    (requirementId: string) => (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.altKey || event.ctrlKey || event.metaKey || event.nativeEvent.isComposing) {
+        return;
+      }
+
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        insertRequirementAfter(requirementId);
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        if (
+          event.shiftKey
+            ? !canOutdentRequirement(requirementId)
+            : !canIndentRequirement(requirementId)
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        if (event.shiftKey) {
+          outdentRequirement(requirementId);
+        } else {
+          indentRequirement(requirementId);
+        }
+        setPendingRequirementFocusId(requirementId);
+        return;
+      }
+
+      if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && !event.shiftKey) {
+        const selectionStart = event.currentTarget.selectionStart;
+        const selectionEnd = event.currentTarget.selectionEnd;
+        if (selectionStart !== selectionEnd) {
+          return;
+        }
+
+        const editableRequirementIds = numberedRequirements
+          .filter(({ requirement }) => requirement.retiredAt === null)
+          .map(({ requirement }) => requirement.id);
+        const currentIndex = editableRequirementIds.indexOf(requirementId);
+        const nextIndex = currentIndex + (event.key === 'ArrowDown' ? 1 : -1);
+        const nextRequirementId = editableRequirementIds[nextIndex];
+        if (!nextRequirementId) {
+          return;
+        }
+
+        event.preventDefault();
+        setPendingRequirementFocusId(nextRequirementId);
+      }
+    };
 
   const saveMatrix = async () => {
     if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
@@ -617,10 +792,12 @@ function App(): React.JSX.Element {
                           aria-label={`Requirement ${displayNumber} text`}
                           className="requirement-text"
                           disabled={!isEditable}
+                          id={requirementTextInputId(requirement.id)}
                           value={requirement.text}
                           onChange={(event) =>
                             editRequirementText(requirement.id, event.target.value)
                           }
+                          onKeyDown={handleRequirementTextKeyDown(requirement.id)}
                         />
                         {isEditable ? (
                           <div className="requirement-actions">

--- a/apps/desktop/tests/e2e/desktop.spec.ts
+++ b/apps/desktop/tests/e2e/desktop.spec.ts
@@ -75,6 +75,22 @@ test.describe
       await expect(firstSession.page.getByText('No requirements yet.')).toBeVisible();
       await firstSession.page.getByRole('button', { name: 'Add Requirement' }).click();
       await firstSession.page.getByLabel('Requirement 1 text').fill('Provide secure hosting');
+      await firstSession.page.getByLabel('Requirement 1 text').press('Enter');
+      await expect(firstSession.page.getByLabel('Requirement 2 text')).toBeFocused();
+      await firstSession.page.keyboard.type('Operate help desk');
+      await firstSession.page.keyboard.press('Tab');
+      await expect(firstSession.page.getByLabel('Requirement 1.1 text')).toBeFocused();
+      await firstSession.page.keyboard.press('Enter');
+      await expect(firstSession.page.getByLabel('Requirement 1.2 text')).toBeFocused();
+      await firstSession.page.keyboard.type('Train operators');
+      await firstSession.page.keyboard.press('ArrowUp');
+      await expect(firstSession.page.getByLabel('Requirement 1.1 text')).toBeFocused();
+      await firstSession.page.keyboard.press('ArrowDown');
+      await expect(firstSession.page.getByLabel('Requirement 1.2 text')).toBeFocused();
+      await firstSession.page.keyboard.type(' on site');
+      await expect(firstSession.page.getByLabel('Requirement 1.2 text')).toHaveValue(
+        'Train operators on site',
+      );
       await firstSession.page.getByRole('button', { name: 'Save Matrix' }).click();
       await expect(firstSession.page.getByText('Saved')).toBeVisible();
       await expect(


### PR DESCRIPTION
## Summary

Adds keyboard-first Base Capability Matrix editing on top of the Issue 8 branch.

- Enter inserts a new active Requirement after the focused Requirement and focuses it.
- Tab and Shift+Tab indent or outdent valid Requirement subtrees while preserving Requirement IDs.
- ArrowDown and ArrowUp move between editable Requirement text fields without blocking normal text edits.
- Invalid outline commands fall through to native focus movement so the editor does not trap focus.

Closes #9

## Verification

- `pnpm --filter @app/desktop exec vitest run src/App.test.tsx`
- `pnpm --filter @app/desktop test:unit`
- `pnpm --filter @app/desktop typecheck`
- `pnpm --filter @app/desktop test:e2e`
- `pnpm --filter @app/desktop check`
