### PR TITLE
Add Base Capability Matrix autosave guard

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2,20 +2,93 @@ import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { createOpportunityService } from '@cmm/application';
+import { cmmWindowLifecycleChannels, validateWindowCloseResponse } from '@cmm/contracts';
 import {
   type CmmSqliteDatabase,
   createCmmSqliteDatabase,
   createSqliteOpportunityRepository,
 } from '@cmm/persistence-sqlite';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, type IpcMainEvent, ipcMain } from 'electron';
 import { registerCmmIpcHandlers } from './cmm-ipc';
 
 const rendererRoot = path.resolve(__dirname, '../dist');
 const preloadPath = path.resolve(__dirname, 'preload.js');
+const closeGuardTimeoutMs = 5000;
 
 let database: CmmSqliteDatabase | null = null;
+let allowAppQuit = false;
+let quitAfterGuardedWindowClose = false;
 
 const getDataDir = () => process.env.CMM_DATA_DIR ?? path.join(app.getPath('userData'), 'data');
+
+const maybeQuitAfterGuardedWindowClose = () => {
+  if (!quitAfterGuardedWindowClose || BrowserWindow.getAllWindows().length > 0) {
+    return;
+  }
+
+  quitAfterGuardedWindowClose = false;
+  allowAppQuit = true;
+  app.quit();
+};
+
+const attachWindowCloseGuard = (window: BrowserWindow) => {
+  let allowClose = false;
+
+  window.on('close', (event) => {
+    if (allowClose || window.webContents.isDestroyed()) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const requestId = randomUUID();
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      ipcMain.off(cmmWindowLifecycleChannels.respondClose, handleCloseResponse);
+    };
+
+    const closeWindow = () => {
+      if (window.isDestroyed()) {
+        return;
+      }
+
+      allowClose = true;
+      window.close();
+    };
+
+    const handleCloseResponse = (_event: IpcMainEvent, rawResponse: unknown) => {
+      let response: ReturnType<typeof validateWindowCloseResponse>;
+      try {
+        response = validateWindowCloseResponse(rawResponse);
+      } catch {
+        return;
+      }
+
+      if (response.requestId !== requestId) {
+        return;
+      }
+
+      cleanup();
+      if (response.canClose) {
+        closeWindow();
+      } else {
+        quitAfterGuardedWindowClose = false;
+      }
+    };
+
+    timeout = setTimeout(() => {
+      quitAfterGuardedWindowClose = false;
+      cleanup();
+    }, closeGuardTimeoutMs);
+
+    ipcMain.on(cmmWindowLifecycleChannels.respondClose, handleCloseResponse);
+    window.webContents.send(cmmWindowLifecycleChannels.requestClose, { requestId });
+  });
+
+  window.on('closed', maybeQuitAfterGuardedWindowClose);
+};
 
 const createWindow = async () => {
   const window = new BrowserWindow({
@@ -30,6 +103,7 @@ const createWindow = async () => {
       nodeIntegration: false,
     },
   });
+  attachWindowCloseGuard(window);
 
   const devServerUrl = process.env.VITE_DEV_SERVER_URL;
   if (devServerUrl) {
@@ -69,12 +143,31 @@ app.whenReady().then(async () => {
   });
 });
 
-app.on('before-quit', () => {
+app.on('before-quit', (event) => {
+  if (allowAppQuit) {
+    return;
+  }
+
+  const windows = BrowserWindow.getAllWindows();
+  if (windows.length === 0) {
+    allowAppQuit = true;
+    return;
+  }
+
+  event.preventDefault();
+  quitAfterGuardedWindowClose = true;
+  for (const window of windows) {
+    window.close();
+  }
+});
+
+app.on('will-quit', () => {
   database?.close();
   database = null;
 });
 
 app.on('window-all-closed', () => {
+  maybeQuitAfterGuardedWindowClose();
   if (process.platform !== 'darwin') {
     app.quit();
   }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,11 +1,14 @@
 import {
   type CreateOpportunityIpcInput,
   cmmIpcContracts,
+  cmmWindowLifecycleChannels,
   type OpenOpportunityIpcInput,
   type OpportunityLifecycleIpcInput,
   type SaveBaseCapabilityMatrixIpcInput,
+  validateWindowCloseRequest,
+  type WindowCloseResponseDto,
 } from '@cmm/contracts';
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, type IpcRendererEvent, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('cmmApi', {
   createOpportunity: (input: CreateOpportunityIpcInput) =>
@@ -26,4 +29,27 @@ contextBridge.exposeInMainWorld('cmmApi', {
     ipcRenderer.invoke(cmmIpcContracts.restoreArchivedOpportunity.channel, input),
   hardDeleteArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.hardDeleteArchivedOpportunity.channel, input),
+  onWindowCloseRequest: (handler: () => boolean | Promise<boolean>) => {
+    const listener = (_event: IpcRendererEvent, rawRequest: unknown) => {
+      const request = validateWindowCloseRequest(rawRequest);
+      void Promise.resolve(handler())
+        .then((canClose) => {
+          const response: WindowCloseResponseDto = {
+            requestId: request.requestId,
+            canClose,
+          };
+          ipcRenderer.send(cmmWindowLifecycleChannels.respondClose, response);
+        })
+        .catch(() => {
+          const response: WindowCloseResponseDto = {
+            requestId: request.requestId,
+            canClose: false,
+          };
+          ipcRenderer.send(cmmWindowLifecycleChannels.respondClose, response);
+        });
+    };
+
+    ipcRenderer.on(cmmWindowLifecycleChannels.requestClose, listener);
+    return () => ipcRenderer.removeListener(cmmWindowLifecycleChannels.requestClose, listener);
+  },
 });

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,5 +1,5 @@
 import type { BaseCapabilityMatrixDto, OpportunityDto } from '@cmm/contracts';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
@@ -22,6 +22,13 @@ const archivedOpportunity: OpportunityDto = {
   name: 'Archived Radar Upgrade',
   updatedAt: '2026-05-01T09:10:00.000Z',
   archivedAt: '2026-05-01T09:10:00.000Z',
+};
+
+const secondActiveOpportunity: OpportunityDto = {
+  ...activeOpportunity,
+  id: 'opportunity-second',
+  name: 'Harbor Sensor Refresh',
+  solicitationNumber: 'RFP-2026-22',
 };
 
 const emptyBaseCapabilityMatrix = (opportunityId: string): BaseCapabilityMatrixDto => ({
@@ -56,6 +63,7 @@ const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
     archiveOpportunity: vi.fn(),
     restoreArchivedOpportunity: vi.fn(),
     hardDeleteArchivedOpportunity: vi.fn(),
+    onWindowCloseRequest: vi.fn(() => () => undefined),
     ...overrides,
   };
 
@@ -68,6 +76,7 @@ const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
 };
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -128,6 +137,70 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Restore Opportunity' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Hard delete Opportunity' })).toBeVisible();
     expect(screen.getByRole('button', { name: 'Open Arctic Radar Upgrade' })).toBeVisible();
+  });
+
+  it('flushes dirty Base Capability Matrix edits before archiving an active Opportunity', async () => {
+    const archivedFromActive = {
+      ...activeOpportunity,
+      updatedAt: '2026-05-01T09:10:00.000Z',
+      archivedAt: '2026-05-01T09:10:00.000Z',
+    };
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    let active: OpportunityDto[] = [activeOpportunity];
+    let archived: OpportunityDto[] = [];
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => active),
+      listArchivedOpportunities: vi.fn(async () => archived),
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      archiveOpportunity: vi.fn(async () => {
+        active = [];
+        archived = [archivedFromActive];
+        return archivedFromActive;
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+    await user.click(screen.getByRole('button', { name: 'Archive Opportunity' }));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 1,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide IL5 hosting',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+    expect(api.archiveOpportunity).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+    });
+    expect(await screen.findByText('Read-only')).toBeVisible();
   });
 
   it('restores archived Opportunities to active work', async () => {
@@ -243,6 +316,313 @@ describe('App', () => {
       ],
     });
     expect(await screen.findByText('Saved')).toBeVisible();
+  });
+
+  it('autosaves dirty active Base Capability Matrix edits and advances the local revision', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+
+    expect(screen.getByText('Dirty')).toBeVisible();
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 1,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide IL5 hosting',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+    expect(await screen.findByText('Saved')).toBeVisible();
+
+    await user.type(screen.getByLabelText('Requirement 1 text'), ' and DR');
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenLastCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 2,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide IL5 hosting and DR',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+  });
+
+  it('flushes dirty Base Capability Matrix edits before switching Opportunities', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => [activeOpportunity, secondActiveOpportunity]),
+      openOpportunity: vi.fn(async ({ opportunityId }) => ({
+        opportunity:
+          opportunityId === secondActiveOpportunity.id
+            ? secondActiveOpportunity
+            : activeOpportunity,
+        baseCapabilityMatrix:
+          opportunityId === secondActiveOpportunity.id
+            ? emptyBaseCapabilityMatrix(secondActiveOpportunity.id)
+            : baseCapabilityMatrix,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+    await user.click(screen.getByRole('button', { name: 'Open Harbor Sensor Refresh' }));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 1,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide IL5 hosting',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+    expect(await screen.findByText('RFP-2026-22')).toBeVisible();
+  });
+
+  it('pauses autosave on stale revision conflicts and blocks guarded actions until recovery', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => [activeOpportunity, secondActiveOpportunity]),
+      openOpportunity: vi.fn(async ({ opportunityId }) => ({
+        opportunity:
+          opportunityId === secondActiveOpportunity.id
+            ? secondActiveOpportunity
+            : activeOpportunity,
+        baseCapabilityMatrix:
+          opportunityId === secondActiveOpportunity.id
+            ? emptyBaseCapabilityMatrix(secondActiveOpportunity.id)
+            : baseCapabilityMatrix,
+      })),
+      saveBaseCapabilityMatrix: vi.fn(async () => {
+        throw new Error('Base Capability Matrix has changed since it was opened.');
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(await screen.findByText('Conflicted')).toBeVisible();
+    expect(screen.getByDisplayValue('Provide IL5 hosting')).toBeVisible();
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledTimes(1);
+
+    await user.type(screen.getByLabelText('Requirement 1 text'), ' with failover');
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Open Harbor Sensor Refresh' }));
+
+    expect(api.openOpportunity).toHaveBeenCalledTimes(1);
+    expect(screen.getByDisplayValue('Provide IL5 hosting with failover')).toBeVisible();
+    expect(
+      screen.getByText('Resolve the Base Capability Matrix conflict before continuing.'),
+    ).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Retry save' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Discard local draft' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Stay on this Opportunity' })).toBeVisible();
+  });
+
+  it('offers retry, stay, and discard recovery choices after a failed guarded flush', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const api = installCmmApi({
+      listActiveOpportunities: vi.fn(async () => [activeOpportunity, secondActiveOpportunity]),
+      openOpportunity: vi.fn(async ({ opportunityId }) => ({
+        opportunity:
+          opportunityId === secondActiveOpportunity.id
+            ? secondActiveOpportunity
+            : activeOpportunity,
+        baseCapabilityMatrix:
+          opportunityId === secondActiveOpportunity.id
+            ? emptyBaseCapabilityMatrix(secondActiveOpportunity.id)
+            : baseCapabilityMatrix,
+      })),
+      saveBaseCapabilityMatrix: vi.fn(async () => {
+        throw new Error('Disk is temporarily unavailable.');
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+    await user.click(screen.getByRole('button', { name: 'Open Harbor Sensor Refresh' }));
+
+    expect(await screen.findByText('Failed')).toBeVisible();
+    expect(screen.getByDisplayValue('Provide IL5 hosting')).toBeVisible();
+    expect(api.openOpportunity).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Stay on this Opportunity' }));
+
+    expect(
+      screen.queryByText('Save or discard Base Capability Matrix edits before continuing.'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Provide IL5 hosting')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Retry save' }));
+
+    await waitFor(() => expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Failed')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Discard local draft' }));
+
+    expect(await screen.findByDisplayValue('Provide secure hosting')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Open Harbor Sensor Refresh' }));
+
+    expect(await screen.findByText('RFP-2026-22')).toBeVisible();
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledTimes(2);
+  });
+
+  it('flushes dirty Base Capability Matrix edits before allowing window close', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const closeRequest: {
+      handler: (() => boolean | Promise<boolean>) | null;
+    } = {
+      handler: null,
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      onWindowCloseRequest: vi.fn((handler) => {
+        closeRequest.handler = handler;
+        return () => {
+          closeRequest.handler = null;
+        };
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+
+    if (!closeRequest.handler) {
+      throw new Error('Window close handler was not registered.');
+    }
+    await expect(Promise.resolve(closeRequest.handler())).resolves.toBe(true);
+
+    expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide IL5 hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
   });
 
   it('inserts a new active Requirement from Enter and focuses the new text field', async () => {
@@ -593,7 +973,7 @@ describe('App', () => {
     await user.click(screen.getByLabelText('Requirement 1 text'));
     await user.keyboard('{Shift>}{Tab}{/Shift}');
 
-    expect(screen.getByRole('button', { name: 'Add Requirement' })).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Save Matrix' })).toHaveFocus();
   });
 
   it('loads archived Opportunity matrices in a read-only workspace', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -7,7 +7,7 @@ import type {
 } from '@cmm/contracts';
 import { Button, Field, TextArea, TextInput } from '@cmm/ui';
 import type { FormEvent, KeyboardEvent } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 type OpportunityFormState = {
   name: string;
@@ -22,7 +22,11 @@ type OpenedOpportunityState = OpenOpportunityIpcOutput & {
   lifecycle: OpportunityListMode;
 };
 
-type MatrixSaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'error' | 'conflict';
+type MatrixSaveState = 'idle' | 'dirty' | 'saving' | 'saved' | 'failed' | 'conflicted';
+type MatrixFlushResult = 'clean' | 'saved' | 'dirty' | 'failed' | 'conflicted';
+type MatrixFlushOptions = {
+  force?: boolean;
+};
 
 type NumberedRequirement = {
   requirement: RequirementDto;
@@ -35,6 +39,8 @@ const emptyForm: OpportunityFormState = {
   issuingAgency: '',
   description: '',
 };
+
+const autosaveDelayMs = 500;
 
 const orderRequirements = (requirements: RequirementDto[]): RequirementDto[] =>
   [...requirements].sort((left, right) => left.position - right.position);
@@ -113,6 +119,12 @@ const formatOpenedAt = (opportunity: OpportunityDto): string => {
   }).format(new Date(opportunity.lastOpenedAt));
 };
 
+const getErrorMessage = (unknownError: unknown, fallback: string): string =>
+  unknownError instanceof Error ? unknownError.message : fallback;
+
+const isBaseCapabilityMatrixRevisionConflict = (message: string): boolean =>
+  message.includes('changed since') || message.includes('revision conflict');
+
 function App(): React.JSX.Element {
   const [opportunities, setOpportunities] = useState<OpportunityDto[]>([]);
   const [archivedOpportunities, setArchivedOpportunities] = useState<OpportunityDto[]>([]);
@@ -124,6 +136,10 @@ function App(): React.JSX.Element {
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
   const [error, setError] = useState<string | null>(null);
+  const openedOpportunityRef = useRef<OpenedOpportunityState | null>(null);
+  const matrixSaveStateRef = useRef<MatrixSaveState>('idle');
+  const draftVersionRef = useRef(0);
+  const savePromiseRef = useRef<Promise<MatrixFlushResult> | null>(null);
 
   const refreshOpportunities = useCallback(async () => {
     const [active, archived] = await Promise.all([
@@ -136,11 +152,17 @@ function App(): React.JSX.Element {
 
   useEffect(() => {
     void refreshOpportunities().catch((unknownError: unknown) => {
-      setError(
-        unknownError instanceof Error ? unknownError.message : 'Unable to load Opportunities.',
-      );
+      setError(getErrorMessage(unknownError, 'Unable to load Opportunities.'));
     });
   }, [refreshOpportunities]);
+
+  useEffect(() => {
+    openedOpportunityRef.current = openedOpportunity;
+  }, [openedOpportunity]);
+
+  useEffect(() => {
+    matrixSaveStateRef.current = matrixSaveState;
+  }, [matrixSaveState]);
 
   useEffect(() => {
     if (!pendingRequirementFocusId) {
@@ -158,7 +180,140 @@ function App(): React.JSX.Element {
     setPendingRequirementFocusId(null);
   }, [pendingRequirementFocusId]);
 
+  const setTrackedMatrixSaveState = useCallback((state: MatrixSaveState) => {
+    matrixSaveStateRef.current = state;
+    setMatrixSaveState(state);
+  }, []);
+
+  const flushBaseCapabilityMatrix = useCallback(
+    async (options: MatrixFlushOptions = {}): Promise<MatrixFlushResult> => {
+      if (savePromiseRef.current) {
+        return savePromiseRef.current;
+      }
+
+      const current = openedOpportunityRef.current;
+      const currentSaveState = matrixSaveStateRef.current;
+      if (!current || current.lifecycle === 'archived') {
+        return 'clean';
+      }
+
+      if (currentSaveState === 'conflicted' && !options.force) {
+        return 'conflicted';
+      }
+
+      if (
+        currentSaveState !== 'dirty' &&
+        currentSaveState !== 'failed' &&
+        !(currentSaveState === 'conflicted' && options.force)
+      ) {
+        return 'clean';
+      }
+
+      const matrixSnapshot = current.baseCapabilityMatrix;
+      const savedOpportunityId = current.opportunity.id;
+      const saveDraftVersion = draftVersionRef.current;
+
+      const savePromise = (async (): Promise<MatrixFlushResult> => {
+        setError(null);
+        setTrackedMatrixSaveState('saving');
+
+        try {
+          const saved = await window.cmmApi.saveBaseCapabilityMatrix(matrixSnapshot);
+          const wasSuperseded = draftVersionRef.current !== saveDraftVersion;
+
+          setOpenedOpportunity((latest) => {
+            if (
+              !latest ||
+              latest.lifecycle !== 'active' ||
+              latest.opportunity.id !== savedOpportunityId
+            ) {
+              return latest;
+            }
+
+            return {
+              ...latest,
+              baseCapabilityMatrix: wasSuperseded
+                ? {
+                    ...latest.baseCapabilityMatrix,
+                    revision: saved.revision,
+                  }
+                : saved,
+            };
+          });
+
+          setTrackedMatrixSaveState(wasSuperseded ? 'dirty' : 'saved');
+          return wasSuperseded ? 'dirty' : 'saved';
+        } catch (unknownError) {
+          const message = getErrorMessage(unknownError, 'Unable to save Base Capability Matrix.');
+          const nextState = isBaseCapabilityMatrixRevisionConflict(message)
+            ? 'conflicted'
+            : 'failed';
+          setError(message);
+          setTrackedMatrixSaveState(nextState);
+          return nextState;
+        } finally {
+          savePromiseRef.current = null;
+        }
+      })();
+
+      savePromiseRef.current = savePromise;
+      return savePromise;
+    },
+    [setTrackedMatrixSaveState],
+  );
+
+  const flushBaseCapabilityMatrixBeforeProceeding = useCallback(async (): Promise<boolean> => {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const result = await flushBaseCapabilityMatrix();
+      if (result === 'clean' || result === 'saved') {
+        return true;
+      }
+
+      if (result !== 'dirty') {
+        setError(
+          result === 'conflicted'
+            ? 'Resolve the Base Capability Matrix conflict before continuing.'
+            : 'Save or discard Base Capability Matrix edits before continuing.',
+        );
+        return false;
+      }
+    }
+
+    setError('Save or discard Base Capability Matrix edits before continuing.');
+    return false;
+  }, [flushBaseCapabilityMatrix]);
+
+  useEffect(
+    () => window.cmmApi.onWindowCloseRequest(flushBaseCapabilityMatrixBeforeProceeding),
+    [flushBaseCapabilityMatrixBeforeProceeding],
+  );
+
+  useEffect(() => {
+    if (
+      matrixSaveState !== 'dirty' ||
+      !openedOpportunity ||
+      openedOpportunity.lifecycle === 'archived'
+    ) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void flushBaseCapabilityMatrix();
+    }, autosaveDelayMs);
+
+    return () => window.clearTimeout(timer);
+  }, [flushBaseCapabilityMatrix, matrixSaveState, openedOpportunity]);
+
   const openOpportunity = async (opportunityId: string) => {
+    const current = openedOpportunityRef.current;
+    if (
+      current &&
+      (current.opportunity.id !== opportunityId || current.lifecycle !== listMode) &&
+      !(await flushBaseCapabilityMatrixBeforeProceeding())
+    ) {
+      return;
+    }
+
     setError(null);
     const opened =
       listMode === 'active'
@@ -169,7 +324,8 @@ function App(): React.JSX.Element {
       lifecycle: listMode,
     });
     setShowRetiredRequirements(false);
-    setMatrixSaveState('idle');
+    draftVersionRef.current = 0;
+    setTrackedMatrixSaveState('idle');
     await refreshOpportunities();
   };
 
@@ -180,6 +336,7 @@ function App(): React.JSX.Element {
       return;
     }
 
+    draftVersionRef.current += 1;
     setOpenedOpportunity((current) => {
       if (!current || current.lifecycle === 'archived') {
         return current;
@@ -194,7 +351,9 @@ function App(): React.JSX.Element {
         },
       };
     });
-    setMatrixSaveState('dirty');
+    if (matrixSaveStateRef.current !== 'conflicted') {
+      setTrackedMatrixSaveState('dirty');
+    }
   };
 
   const addRequirement = () => {
@@ -446,33 +605,35 @@ function App(): React.JSX.Element {
     };
 
   const saveMatrix = async () => {
-    if (!openedOpportunity || openedOpportunity.lifecycle === 'archived') {
+    await flushBaseCapabilityMatrix({ force: matrixSaveStateRef.current === 'conflicted' });
+  };
+
+  const discardMatrixDraft = async () => {
+    const current = openedOpportunityRef.current;
+    if (!current || current.lifecycle !== 'active') {
       return;
     }
 
     setError(null);
-    setMatrixSaveState('saving');
     try {
-      const saved = await window.cmmApi.saveBaseCapabilityMatrix(
-        openedOpportunity.baseCapabilityMatrix,
-      );
-      setOpenedOpportunity((current) =>
-        current
-          ? {
-              ...current,
-              baseCapabilityMatrix: saved,
-            }
-          : current,
-      );
-      setMatrixSaveState('saved');
+      const opened = await window.cmmApi.openOpportunity({
+        opportunityId: current.opportunity.id,
+      });
+      setOpenedOpportunity({
+        ...opened,
+        lifecycle: 'active',
+      });
+      draftVersionRef.current = 0;
+      setShowRetiredRequirements(false);
+      setTrackedMatrixSaveState('idle');
+      await refreshOpportunities();
     } catch (unknownError) {
-      const message =
-        unknownError instanceof Error
-          ? unknownError.message
-          : 'Unable to save Base Capability Matrix.';
-      setError(message);
-      setMatrixSaveState(message.includes('changed since') ? 'conflict' : 'error');
+      setError(getErrorMessage(unknownError, 'Unable to reload Base Capability Matrix.'));
     }
+  };
+
+  const stayOnCurrentOpportunity = () => {
+    setError(null);
   };
 
   const createOpportunity = async (event: FormEvent<HTMLFormElement>) => {
@@ -485,9 +646,7 @@ function App(): React.JSX.Element {
       setIsCreating(false);
       await openOpportunity(created.id);
     } catch (unknownError) {
-      setError(
-        unknownError instanceof Error ? unknownError.message : 'Unable to create Opportunity.',
-      );
+      setError(getErrorMessage(unknownError, 'Unable to create Opportunity.'));
     }
   };
 
@@ -498,6 +657,10 @@ function App(): React.JSX.Element {
 
     setError(null);
     try {
+      if (!(await flushBaseCapabilityMatrixBeforeProceeding())) {
+        return;
+      }
+
       const archived = await window.cmmApi.archiveOpportunity({
         opportunityId: openedOpportunity.opportunity.id,
       });
@@ -509,9 +672,7 @@ function App(): React.JSX.Element {
         lifecycle: 'archived',
       });
     } catch (unknownError) {
-      setError(
-        unknownError instanceof Error ? unknownError.message : 'Unable to archive Opportunity.',
-      );
+      setError(getErrorMessage(unknownError, 'Unable to archive Opportunity.'));
     }
   };
 
@@ -533,9 +694,7 @@ function App(): React.JSX.Element {
         lifecycle: 'active',
       });
     } catch (unknownError) {
-      setError(
-        unknownError instanceof Error ? unknownError.message : 'Unable to restore Opportunity.',
-      );
+      setError(getErrorMessage(unknownError, 'Unable to restore Opportunity.'));
     }
   };
 
@@ -560,9 +719,7 @@ function App(): React.JSX.Element {
       setListMode('archived');
       setOpenedOpportunity(null);
     } catch (unknownError) {
-      setError(
-        unknownError instanceof Error ? unknownError.message : 'Unable to hard delete Opportunity.',
-      );
+      setError(getErrorMessage(unknownError, 'Unable to hard delete Opportunity.'));
     }
   };
 
@@ -582,15 +739,15 @@ function App(): React.JSX.Element {
     ).length ?? 0;
   const matrixStatusLabel =
     matrixSaveState === 'dirty'
-      ? 'Unsaved'
+      ? 'Dirty'
       : matrixSaveState === 'saving'
         ? 'Saving'
         : matrixSaveState === 'saved'
           ? 'Saved'
-          : matrixSaveState === 'conflict'
-            ? 'Conflict'
-            : matrixSaveState === 'error'
-              ? 'Error'
+          : matrixSaveState === 'conflicted'
+            ? 'Conflicted'
+            : matrixSaveState === 'failed'
+              ? 'Failed'
               : '';
 
   return (
@@ -749,7 +906,7 @@ function App(): React.JSX.Element {
                     Add Requirement
                   </Button>
                   <Button
-                    disabled={matrixSaveState !== 'dirty'}
+                    disabled={matrixSaveState === 'saving'}
                     variant="secondary"
                     onClick={() => void saveMatrix()}
                   >
@@ -768,6 +925,19 @@ function App(): React.JSX.Element {
                   ) : null}
                   {matrixStatusLabel ? (
                     <span className="matrix-save-status">{matrixStatusLabel}</span>
+                  ) : null}
+                  {matrixSaveState === 'failed' || matrixSaveState === 'conflicted' ? (
+                    <div className="matrix-recovery-actions">
+                      <Button variant="secondary" onClick={() => void saveMatrix()}>
+                        Retry save
+                      </Button>
+                      <Button variant="secondary" onClick={() => void discardMatrixDraft()}>
+                        Discard local draft
+                      </Button>
+                      <Button variant="ghost" onClick={stayOnCurrentOpportunity}>
+                        Stay on this Opportunity
+                      </Button>
+                    </div>
                   ) : null}
                 </div>
               ) : null}

--- a/apps/desktop/src/electron-api.d.ts
+++ b/apps/desktop/src/electron-api.d.ts
@@ -23,6 +23,7 @@ export interface CmmApi {
   hardDeleteArchivedOpportunity(
     input: OpportunityLifecycleIpcInput,
   ): Promise<HardDeleteArchivedOpportunityIpcOutput>;
+  onWindowCloseRequest(handler: () => boolean | Promise<boolean>): () => void;
 }
 
 declare global {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -51,6 +51,15 @@ const hardDeleteArchivedOpportunityOutputSchema = z.object({
   opportunityId: z.string().min(1),
 });
 
+const windowCloseRequestSchema = z.object({
+  requestId: z.string().min(1),
+});
+
+const windowCloseResponseSchema = z.object({
+  requestId: z.string().min(1),
+  canClose: z.boolean(),
+});
+
 export type OpportunityDto = z.infer<typeof opportunitySchema>;
 export type RequirementDto = z.infer<typeof requirementSchema>;
 export type BaseCapabilityMatrixDto = z.infer<typeof baseCapabilityMatrixSchema>;
@@ -62,6 +71,8 @@ export type SaveBaseCapabilityMatrixIpcInput = z.infer<typeof baseCapabilityMatr
 export type HardDeleteArchivedOpportunityIpcOutput = z.infer<
   typeof hardDeleteArchivedOpportunityOutputSchema
 >;
+export type WindowCloseRequestDto = z.infer<typeof windowCloseRequestSchema>;
+export type WindowCloseResponseDto = z.infer<typeof windowCloseResponseSchema>;
 
 export type IpcContract<Input, Output> = {
   channel: string;
@@ -121,6 +132,11 @@ export const cmmIpcContracts = {
   }),
 };
 
+export const cmmWindowLifecycleChannels = {
+  requestClose: 'cmm:window:request-close',
+  respondClose: 'cmm:window:respond-close',
+} as const;
+
 export const validateIpcInput = <Input, Output>(
   contract: IpcContract<Input, Output>,
   value: unknown,
@@ -130,3 +146,9 @@ export const validateIpcOutput = <Input, Output>(
   contract: IpcContract<Input, Output>,
   value: unknown,
 ): Output => contract.outputSchema.parse(value);
+
+export const validateWindowCloseRequest = (value: unknown): WindowCloseRequestDto =>
+  windowCloseRequestSchema.parse(value);
+
+export const validateWindowCloseResponse = (value: unknown): WindowCloseResponseDto =>
+  windowCloseResponseSchema.parse(value);

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { cmmIpcContracts, validateIpcInput, validateIpcOutput } from './index';
+import {
+  cmmIpcContracts,
+  cmmWindowLifecycleChannels,
+  validateIpcInput,
+  validateIpcOutput,
+  validateWindowCloseRequest,
+  validateWindowCloseResponse,
+} from './index';
 
 const opportunity = {
   id: 'opportunity-1',
@@ -51,6 +58,8 @@ describe('Opportunity IPC contracts', () => {
       'cmm:opportunities:hard-delete-archived',
     );
     expect(cmmIpcContracts.saveBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:save');
+    expect(cmmWindowLifecycleChannels.requestClose).toBe('cmm:window:request-close');
+    expect(cmmWindowLifecycleChannels.respondClose).toBe('cmm:window:respond-close');
 
     expect(
       validateIpcInput(cmmIpcContracts.createOpportunity, {
@@ -147,5 +156,13 @@ describe('Opportunity IPC contracts', () => {
     ).toEqual({
       opportunityId: 'opportunity-1',
     });
+    expect(validateWindowCloseRequest({ requestId: 'close-1' })).toEqual({
+      requestId: 'close-1',
+    });
+    expect(validateWindowCloseResponse({ requestId: 'close-1', canClose: false })).toEqual({
+      requestId: 'close-1',
+      canClose: false,
+    });
+    expect(() => validateWindowCloseResponse({ requestId: '', canClose: true })).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Adds revision-guarded autosave and manual flush behavior for active Base Capability Matrix edits.

- Debounces dirty matrix edits and saves through the existing saveBaseCapabilityMatrix IPC path.
- Shows Dirty, Saving, Saved, Failed, and Conflicted states in the renderer.
- Reuses one flush guard for manual save, Opportunity switching, active Opportunity archive, and window/app close.
- Adds retry, discard/reload, and stay recovery actions for failed or conflicted flushes.
- Adds typed window-close request/response contracts and preload/main wiring so Electron close waits for the renderer flush guard.

Closes #10

## Validation

- pnpm check
- pnpm typecheck
- pnpm --filter=@app/desktop test:unit
- pnpm --filter=@cmm/contracts test
- pnpm --filter=@app/desktop test:e2e