### PR TITLE
Export protected Base Capability Matrix workbooks

### DIFF
--- a/apps/desktop/electron/base-capability-matrix-export.test.ts
+++ b/apps/desktop/electron/base-capability-matrix-export.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+import type { OpportunityService } from '@cmm/application';
+import { describe, expect, it, vi } from 'vitest';
+import { createBaseCapabilityMatrixExportFileService } from './base-capability-matrix-export';
+
+const opportunityService = (): OpportunityService => ({
+  createOpportunity: vi.fn(),
+  listActiveOpportunities: vi.fn(),
+  listArchivedOpportunities: vi.fn(),
+  openOpportunity: vi.fn(),
+  openArchivedOpportunity: vi.fn(),
+  saveBaseCapabilityMatrix: vi.fn(),
+  exportBaseCapabilityMatrix: vi.fn(async () => ({
+    workbook: new Uint8Array([1, 2, 3]),
+    suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    exportTimestamp: '2026-05-02T10:00:00.000Z',
+  })),
+  archiveOpportunity: vi.fn(),
+  restoreArchivedOpportunity: vi.fn(),
+  hardDeleteArchivedOpportunity: vi.fn(),
+});
+
+describe('Base Capability Matrix export file service', () => {
+  it('writes exported workbook buffers through main-owned file IO', async () => {
+    const service = opportunityService();
+    const writeFile = vi.fn(async () => undefined);
+    const exportFileService = createBaseCapabilityMatrixExportFileService({
+      opportunityService: service,
+      showSaveDialog: vi.fn(async () => ({
+        canceled: false,
+        filePath: '/tmp/Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      })),
+      writeFile,
+    });
+
+    await expect(
+      exportFileService.exportBaseCapabilityMatrix({ opportunityId: 'opportunity-1' }),
+    ).resolves.toEqual({
+      status: 'exported',
+      filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    });
+    expect(service.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
+    });
+    expect(writeFile).toHaveBeenCalledWith(
+      '/tmp/Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      new Uint8Array([1, 2, 3]),
+    );
+  });
+
+  it('does not write a workbook when the save dialog is canceled', async () => {
+    const service = opportunityService();
+    const writeFile = vi.fn(async () => undefined);
+    const exportFileService = createBaseCapabilityMatrixExportFileService({
+      opportunityService: service,
+      showSaveDialog: vi.fn(async () => ({
+        canceled: true,
+      })),
+      writeFile,
+    });
+
+    await expect(
+      exportFileService.exportBaseCapabilityMatrix({ opportunityId: 'opportunity-1' }),
+    ).resolves.toEqual({
+      status: 'canceled',
+      filename: null,
+    });
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/base-capability-matrix-export.ts
+++ b/apps/desktop/electron/base-capability-matrix-export.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import type { OpportunityService } from '@cmm/application';
+import type {
+  ExportBaseCapabilityMatrixIpcInput,
+  ExportBaseCapabilityMatrixIpcOutput,
+} from '@cmm/contracts';
+
+export type SaveDialogResult = {
+  canceled: boolean;
+  filePath?: string;
+};
+
+export type SaveDialog = (options: {
+  title: string;
+  defaultPath: string;
+  filters: { name: string; extensions: string[] }[];
+}) => Promise<SaveDialogResult>;
+
+export type WriteFile = (filePath: string, data: Uint8Array) => Promise<void>;
+
+export type BaseCapabilityMatrixExportFileService = {
+  exportBaseCapabilityMatrix(
+    input: ExportBaseCapabilityMatrixIpcInput,
+  ): Promise<ExportBaseCapabilityMatrixIpcOutput>;
+};
+
+export type CreateBaseCapabilityMatrixExportFileServiceOptions = {
+  opportunityService: OpportunityService;
+  showSaveDialog: SaveDialog;
+  writeFile: WriteFile;
+};
+
+export const createBaseCapabilityMatrixExportFileService = ({
+  opportunityService,
+  showSaveDialog,
+  writeFile,
+}: CreateBaseCapabilityMatrixExportFileServiceOptions): BaseCapabilityMatrixExportFileService => ({
+  async exportBaseCapabilityMatrix(input) {
+    const exportResult = await opportunityService.exportBaseCapabilityMatrix(input);
+    const saveDialogResult = await showSaveDialog({
+      title: 'Export Base Capability Matrix',
+      defaultPath: exportResult.suggestedFilename,
+      filters: [{ name: 'Excel Workbook', extensions: ['xlsx'] }],
+    });
+
+    if (saveDialogResult.canceled || !saveDialogResult.filePath) {
+      return {
+        status: 'canceled',
+        filename: null,
+      };
+    }
+
+    await writeFile(saveDialogResult.filePath, exportResult.workbook);
+    return {
+      status: 'exported',
+      filename: path.basename(saveDialogResult.filePath),
+    };
+  },
+});

--- a/apps/desktop/electron/cmm-ipc.test.ts
+++ b/apps/desktop/electron/cmm-ipc.test.ts
@@ -69,6 +69,11 @@ describe('registerCmmIpcHandlers', () => {
         baseCapabilityMatrix,
       })),
       saveBaseCapabilityMatrix: vi.fn(async () => baseCapabilityMatrix),
+      exportBaseCapabilityMatrix: vi.fn(async () => ({
+        workbook: new Uint8Array([1, 2, 3]),
+        suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+        exportTimestamp: '2026-05-02T10:00:00.000Z',
+      })),
       archiveOpportunity: vi.fn(async () => ({
         ...opportunity,
         archivedAt: '2026-05-01T09:10:00.000Z',
@@ -76,8 +81,14 @@ describe('registerCmmIpcHandlers', () => {
       restoreArchivedOpportunity: vi.fn(async () => opportunity),
       hardDeleteArchivedOpportunity: vi.fn(async () => undefined),
     };
+    const baseCapabilityMatrixExportFileService = {
+      exportBaseCapabilityMatrix: vi.fn(async () => ({
+        status: 'exported' as const,
+        filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      })),
+    };
 
-    registerCmmIpcHandlers(ipcMain, { opportunityService });
+    registerCmmIpcHandlers(ipcMain, { opportunityService, baseCapabilityMatrixExportFileService });
 
     expect(Array.from(ipcMain.handlers.keys()).sort()).toEqual(
       [
@@ -87,6 +98,7 @@ describe('registerCmmIpcHandlers', () => {
         cmmIpcContracts.openOpportunity.channel,
         cmmIpcContracts.openArchivedOpportunity.channel,
         cmmIpcContracts.saveBaseCapabilityMatrix.channel,
+        cmmIpcContracts.exportBaseCapabilityMatrix.channel,
         cmmIpcContracts.archiveOpportunity.channel,
         cmmIpcContracts.restoreArchivedOpportunity.channel,
         cmmIpcContracts.hardDeleteArchivedOpportunity.channel,
@@ -124,6 +136,20 @@ describe('registerCmmIpcHandlers', () => {
       baseCapabilityMatrix,
     );
     expect(opportunityService.saveBaseCapabilityMatrix).toHaveBeenCalledWith(baseCapabilityMatrix);
+
+    const exportMatrixHandler = ipcMain.handlers.get(
+      cmmIpcContracts.exportBaseCapabilityMatrix.channel,
+    );
+    await expect(exportMatrixHandler?.({}, { opportunityId: '' })).rejects.toThrow(
+      'Opportunity ID is required.',
+    );
+    await expect(exportMatrixHandler?.({}, { opportunityId: 'opportunity-1' })).resolves.toEqual({
+      status: 'exported',
+      filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    });
+    expect(baseCapabilityMatrixExportFileService.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
+    });
 
     const hardDeleteHandler = ipcMain.handlers.get(
       cmmIpcContracts.hardDeleteArchivedOpportunity.channel,

--- a/apps/desktop/electron/cmm-ipc.ts
+++ b/apps/desktop/electron/cmm-ipc.ts
@@ -1,6 +1,8 @@
 import type { OpportunityService } from '@cmm/application';
 import {
   cmmIpcContracts,
+  type ExportBaseCapabilityMatrixIpcInput,
+  type ExportBaseCapabilityMatrixIpcOutput,
   type IpcContract,
   validateIpcInput,
   validateIpcOutput,
@@ -14,6 +16,11 @@ export type IpcMainLike = {
 
 export type CmmIpcServices = {
   opportunityService: OpportunityService;
+  baseCapabilityMatrixExportFileService: {
+    exportBaseCapabilityMatrix(
+      input: ExportBaseCapabilityMatrixIpcInput,
+    ): Promise<ExportBaseCapabilityMatrixIpcOutput>;
+  };
 };
 
 const registerValidatedHandler = <Input, Output>(
@@ -30,7 +37,7 @@ const registerValidatedHandler = <Input, Output>(
 
 export const registerCmmIpcHandlers = (
   ipcMain: IpcMainLike,
-  { opportunityService }: CmmIpcServices,
+  { opportunityService, baseCapabilityMatrixExportFileService }: CmmIpcServices,
 ): void => {
   registerValidatedHandler(ipcMain, cmmIpcContracts.createOpportunity, (input) =>
     opportunityService.createOpportunity(input),
@@ -49,6 +56,9 @@ export const registerCmmIpcHandlers = (
   );
   registerValidatedHandler(ipcMain, cmmIpcContracts.saveBaseCapabilityMatrix, (input) =>
     opportunityService.saveBaseCapabilityMatrix(input),
+  );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.exportBaseCapabilityMatrix, (input) =>
+    baseCapabilityMatrixExportFileService.exportBaseCapabilityMatrix(input),
   );
   registerValidatedHandler(ipcMain, cmmIpcContracts.archiveOpportunity, (input) =>
     opportunityService.archiveOpportunity(input),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createOpportunityService } from '@cmm/application';
 import { cmmWindowLifecycleChannels, validateWindowCloseResponse } from '@cmm/contracts';
@@ -8,7 +9,9 @@ import {
   createCmmSqliteDatabase,
   createSqliteOpportunityRepository,
 } from '@cmm/persistence-sqlite';
-import { app, BrowserWindow, type IpcMainEvent, ipcMain } from 'electron';
+import { buildBaseCapabilityMatrixWorkbook } from '@cmm/workbook';
+import { app, BrowserWindow, dialog, type IpcMainEvent, ipcMain } from 'electron';
+import { createBaseCapabilityMatrixExportFileService } from './base-capability-matrix-export';
 import { registerCmmIpcHandlers } from './cmm-ipc';
 
 const rendererRoot = path.resolve(__dirname, '../dist');
@@ -127,9 +130,17 @@ const registerHandlers = () => {
     ids: {
       next: () => randomUUID(),
     },
+    workbookBuilder: {
+      buildBaseCapabilityMatrixWorkbook,
+    },
+  });
+  const baseCapabilityMatrixExportFileService = createBaseCapabilityMatrixExportFileService({
+    opportunityService,
+    showSaveDialog: (options) => dialog.showSaveDialog(options),
+    writeFile,
   });
 
-  registerCmmIpcHandlers(ipcMain, { opportunityService });
+  registerCmmIpcHandlers(ipcMain, { opportunityService, baseCapabilityMatrixExportFileService });
 };
 
 app.whenReady().then(async () => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -2,6 +2,7 @@ import {
   type CreateOpportunityIpcInput,
   cmmIpcContracts,
   cmmWindowLifecycleChannels,
+  type ExportBaseCapabilityMatrixIpcInput,
   type OpenOpportunityIpcInput,
   type OpportunityLifecycleIpcInput,
   type SaveBaseCapabilityMatrixIpcInput,
@@ -23,6 +24,8 @@ contextBridge.exposeInMainWorld('cmmApi', {
     ipcRenderer.invoke(cmmIpcContracts.openArchivedOpportunity.channel, input),
   saveBaseCapabilityMatrix: (input: SaveBaseCapabilityMatrixIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.saveBaseCapabilityMatrix.channel, input),
+  exportBaseCapabilityMatrix: (input: ExportBaseCapabilityMatrixIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.exportBaseCapabilityMatrix.channel, input),
   archiveOpportunity: (input: OpportunityLifecycleIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.archiveOpportunity.channel, input),
   restoreArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
     "@cmm/domain": "workspace:*",
     "@cmm/persistence-sqlite": "workspace:*",
     "@cmm/ui": "workspace:*",
+    "@cmm/workbook": "workspace:*",
     "electron": "^41.2.1",
     "react": "19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -60,6 +60,10 @@ const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
       ...matrix,
       revision: matrix.revision + 1,
     })),
+    exportBaseCapabilityMatrix: vi.fn(async () => ({
+      status: 'exported' as const,
+      filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    })),
     archiveOpportunity: vi.fn(),
     restoreArchivedOpportunity: vi.fn(),
     hardDeleteArchivedOpportunity: vi.fn(),
@@ -623,6 +627,74 @@ describe('App', () => {
         },
       ],
     });
+  });
+
+  it('flushes dirty Base Capability Matrix edits before exporting the workbook', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const calls: string[] = [];
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      saveBaseCapabilityMatrix: vi.fn(async (matrix) => {
+        calls.push('save');
+        return {
+          ...matrix,
+          revision: matrix.revision + 1,
+        };
+      }),
+      exportBaseCapabilityMatrix: vi.fn(async () => {
+        calls.push('export');
+        return {
+          status: 'exported' as const,
+          filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+        };
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.type(screen.getByLabelText('Requirement 1 text'), 'Provide IL5 hosting');
+    await user.click(screen.getByRole('button', { name: 'Export Workbook' }));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 1,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: 'Provide IL5 hosting',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+    expect(api.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+    });
+    expect(calls).toEqual(['save', 'export']);
+    expect(
+      await screen.findByText('Exported Arctic Radar Upgrade - Base Capability Matrix.xlsx'),
+    ).toBeVisible();
   });
 
   it('inserts a new active Requirement from Enter and focuses the new text field', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -136,6 +136,7 @@ function App(): React.JSX.Element {
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const openedOpportunityRef = useRef<OpenedOpportunityState | null>(null);
   const matrixSaveStateRef = useRef<MatrixSaveState>('idle');
   const draftVersionRef = useRef(0);
@@ -676,6 +677,27 @@ function App(): React.JSX.Element {
     }
   };
 
+  const exportOpenedBaseCapabilityMatrix = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle !== 'active') {
+      return;
+    }
+
+    setError(null);
+    setNotice(null);
+    try {
+      if (!(await flushBaseCapabilityMatrixBeforeProceeding())) {
+        return;
+      }
+
+      const result = await window.cmmApi.exportBaseCapabilityMatrix({
+        opportunityId: openedOpportunity.opportunity.id,
+      });
+      setNotice(result.status === 'exported' ? `Exported ${result.filename}` : 'Export canceled.');
+    } catch (unknownError) {
+      setError(getErrorMessage(unknownError, 'Unable to export Base Capability Matrix.'));
+    }
+  };
+
   const restoreOpenedOpportunity = async () => {
     if (!openedOpportunity || openedOpportunity.lifecycle !== 'archived') {
       return;
@@ -908,6 +930,13 @@ function App(): React.JSX.Element {
                   <Button
                     disabled={matrixSaveState === 'saving'}
                     variant="secondary"
+                    onClick={() => void exportOpenedBaseCapabilityMatrix()}
+                  >
+                    Export Workbook
+                  </Button>
+                  <Button
+                    disabled={matrixSaveState === 'saving'}
+                    variant="secondary"
                     onClick={() => void saveMatrix()}
                   >
                     Save Matrix
@@ -939,6 +968,7 @@ function App(): React.JSX.Element {
                       </Button>
                     </div>
                   ) : null}
+                  {notice ? <span className="matrix-save-status">{notice}</span> : null}
                 </div>
               ) : null}
 

--- a/apps/desktop/src/electron-api.d.ts
+++ b/apps/desktop/src/electron-api.d.ts
@@ -2,6 +2,8 @@ import type {
   CreateOpportunityIpcInput,
   BaseCapabilityMatrixDto,
   HardDeleteArchivedOpportunityIpcOutput,
+  ExportBaseCapabilityMatrixIpcInput,
+  ExportBaseCapabilityMatrixIpcOutput,
   OpenOpportunityIpcInput,
   OpenOpportunityIpcOutput,
   OpportunityLifecycleIpcInput,
@@ -18,6 +20,9 @@ export interface CmmApi {
   saveBaseCapabilityMatrix(
     input: SaveBaseCapabilityMatrixIpcInput,
   ): Promise<BaseCapabilityMatrixDto>;
+  exportBaseCapabilityMatrix(
+    input: ExportBaseCapabilityMatrixIpcInput,
+  ): Promise<ExportBaseCapabilityMatrixIpcOutput>;
   archiveOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   restoreArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   hardDeleteArchivedOpportunity(

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -12,7 +12,8 @@
       "@cmm/contracts": ["../../packages/contracts/src/index.ts"],
       "@cmm/domain": ["../../packages/domain/src/index.ts"],
       "@cmm/persistence-sqlite": ["../../packages/persistence-sqlite/src/index.ts"],
-      "@cmm/ui": ["../../packages/cmm-ui/src/index.tsx"]
+      "@cmm/ui": ["../../packages/cmm-ui/src/index.tsx"],
+      "@cmm/workbook": ["../../packages/workbook/src/index.ts"]
     }
   },
   "include": [
@@ -28,6 +29,7 @@
     "../../packages/cmm-ui/src/**/*.tsx",
     "../../packages/domain/src/**/*.ts",
     "../../packages/persistence-sqlite/src/**/*.ts",
+    "../../packages/workbook/src/**/*.ts",
     "../../packages/core/src/excel-buffer.ts"
   ]
 }

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -62,9 +62,31 @@ export type SaveBaseCapabilityMatrixInput = {
   requirements: Requirement[];
 };
 
+export type ExportBaseCapabilityMatrixInput = {
+  opportunityId: OpportunityId;
+};
+
 export type OpenOpportunityResult = {
   opportunity: Opportunity;
   baseCapabilityMatrix: BaseCapabilityMatrix;
+};
+
+export type BuildBaseCapabilityMatrixWorkbookInput = {
+  opportunity: Opportunity;
+  exportTimestamp: IsoDateTime;
+  requirements: Requirement[];
+};
+
+export type BaseCapabilityMatrixWorkbookBuilder = {
+  buildBaseCapabilityMatrixWorkbook(
+    input: BuildBaseCapabilityMatrixWorkbookInput,
+  ): Promise<Uint8Array>;
+};
+
+export type ExportBaseCapabilityMatrixResult = {
+  workbook: Uint8Array;
+  suggestedFilename: string;
+  exportTimestamp: IsoDateTime;
 };
 
 export type OpportunityService = {
@@ -74,6 +96,9 @@ export type OpportunityService = {
   openOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
   openArchivedOpportunity(input: OpenOpportunityInput): Promise<OpenOpportunityResult>;
   saveBaseCapabilityMatrix(input: SaveBaseCapabilityMatrixInput): Promise<BaseCapabilityMatrix>;
+  exportBaseCapabilityMatrix(
+    input: ExportBaseCapabilityMatrixInput,
+  ): Promise<ExportBaseCapabilityMatrixResult>;
   archiveOpportunity(input: ArchiveOpportunityInput): Promise<Opportunity>;
   restoreArchivedOpportunity(input: RestoreArchivedOpportunityInput): Promise<Opportunity>;
   hardDeleteArchivedOpportunity(input: HardDeleteArchivedOpportunityInput): Promise<void>;
@@ -83,6 +108,7 @@ export type CreateOpportunityServiceOptions = {
   repository: OpportunityRepository;
   clock: Clock;
   ids: IdGenerator;
+  workbookBuilder?: BaseCapabilityMatrixWorkbookBuilder;
 };
 
 export class ApplicationError extends Error {
@@ -102,6 +128,7 @@ export const createOpportunityService = ({
   repository,
   clock,
   ids,
+  workbookBuilder,
 }: CreateOpportunityServiceOptions): OpportunityService => ({
   async createOpportunity(input) {
     const name = normalizeRequiredText(input.name);
@@ -176,6 +203,30 @@ export const createOpportunityService = ({
     });
   },
 
+  async exportBaseCapabilityMatrix(input) {
+    const opportunity = await repository.findActiveOpportunityById(input.opportunityId);
+    if (!opportunity) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+    if (!workbookBuilder) {
+      throw new Error('Base Capability Matrix workbook builder is not configured.');
+    }
+
+    const baseCapabilityMatrix = await repository.loadBaseCapabilityMatrix(input.opportunityId);
+    const exportTimestamp = clock.now();
+    const workbook = await workbookBuilder.buildBaseCapabilityMatrixWorkbook({
+      opportunity,
+      exportTimestamp,
+      requirements: baseCapabilityMatrix.requirements,
+    });
+
+    return {
+      workbook,
+      suggestedFilename: `${toWorkbookFilenameStem(opportunity.name)} - Base Capability Matrix.xlsx`,
+      exportTimestamp,
+    };
+  },
+
   async archiveOpportunity(input) {
     const existing = await repository.findActiveOpportunityById(input.opportunityId);
     if (!existing) {
@@ -203,3 +254,13 @@ export const createOpportunityService = ({
     await repository.hardDeleteArchivedOpportunity(input.opportunityId);
   },
 });
+
+const invalidFilenameCharacters = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*']);
+
+const sanitizeFilenameCharacter = (character: string): string =>
+  invalidFilenameCharacters.has(character) || character.charCodeAt(0) < 32 ? ' ' : character;
+
+const toWorkbookFilenameStem = (name: string): string => {
+  const stem = name.split('').map(sanitizeFilenameCharacter).join('').replace(/\s+/g, ' ').trim();
+  return stem.length > 0 ? stem : 'Opportunity';
+};

--- a/packages/application/src/opportunity-service.test.ts
+++ b/packages/application/src/opportunity-service.test.ts
@@ -1,6 +1,10 @@
 import type { BaseCapabilityMatrix, IsoDateTime, Opportunity, OpportunityId } from '@cmm/domain';
 import { describe, expect, it } from 'vitest';
-import { createOpportunityService, type OpportunityRepository } from './index';
+import {
+  type BuildBaseCapabilityMatrixWorkbookInput,
+  createOpportunityService,
+  type OpportunityRepository,
+} from './index';
 
 class InMemoryOpportunityRepository implements OpportunityRepository {
   readonly opportunities = new Map<OpportunityId, Opportunity>();
@@ -385,6 +389,56 @@ describe('OpportunityService', () => {
         requirements: [],
       }),
     ).rejects.toThrow('Opportunity not found.');
+  });
+
+  it('exports the active Opportunity Base Capability Matrix through the workbook builder', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const builtWorkbooks: BuildBaseCapabilityMatrixWorkbookInput[] = [];
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-02T10:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+      workbookBuilder: {
+        async buildBaseCapabilityMatrixWorkbook(input) {
+          builtWorkbooks.push(input);
+          return new Uint8Array([1, 2, 3]);
+        },
+      },
+    });
+
+    const opportunity = await service.createOpportunity({
+      name: 'Arctic Radar Upgrade',
+      solicitationNumber: 'RFP-2026-17',
+      issuingAgency: 'Naval Systems Command',
+    });
+    const saved = await service.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    await expect(
+      service.exportBaseCapabilityMatrix({ opportunityId: opportunity.id }),
+    ).resolves.toEqual({
+      workbook: new Uint8Array([1, 2, 3]),
+      suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      exportTimestamp: '2026-05-02T10:00:00.000Z',
+    });
+    expect(builtWorkbooks).toEqual([
+      {
+        opportunity,
+        exportTimestamp: '2026-05-02T10:00:00.000Z',
+        requirements: saved.requirements,
+      },
+    ]);
   });
 
   it('hard-deletes an archived Opportunity', async () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -51,6 +51,17 @@ const hardDeleteArchivedOpportunityOutputSchema = z.object({
   opportunityId: z.string().min(1),
 });
 
+const exportBaseCapabilityMatrixOutputSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('exported'),
+    filename: z.string().min(1),
+  }),
+  z.object({
+    status: z.literal('canceled'),
+    filename: z.null(),
+  }),
+]);
+
 const windowCloseRequestSchema = z.object({
   requestId: z.string().min(1),
 });
@@ -68,6 +79,10 @@ export type OpenOpportunityIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type OpenOpportunityIpcOutput = z.infer<typeof openOpportunityOutputSchema>;
 export type OpportunityLifecycleIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type SaveBaseCapabilityMatrixIpcInput = z.infer<typeof baseCapabilityMatrixSchema>;
+export type ExportBaseCapabilityMatrixIpcInput = z.infer<typeof opportunityIdInputSchema>;
+export type ExportBaseCapabilityMatrixIpcOutput = z.infer<
+  typeof exportBaseCapabilityMatrixOutputSchema
+>;
 export type HardDeleteArchivedOpportunityIpcOutput = z.infer<
   typeof hardDeleteArchivedOpportunityOutputSchema
 >;
@@ -114,6 +129,11 @@ export const cmmIpcContracts = {
     channel: 'cmm:base-matrices:save',
     inputSchema: baseCapabilityMatrixSchema,
     outputSchema: baseCapabilityMatrixSchema,
+  }),
+  exportBaseCapabilityMatrix: defineContract({
+    channel: 'cmm:base-matrices:export',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: exportBaseCapabilityMatrixOutputSchema,
   }),
   archiveOpportunity: defineContract({
     channel: 'cmm:opportunities:archive',

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -58,6 +58,7 @@ describe('Opportunity IPC contracts', () => {
       'cmm:opportunities:hard-delete-archived',
     );
     expect(cmmIpcContracts.saveBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:save');
+    expect(cmmIpcContracts.exportBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:export');
     expect(cmmWindowLifecycleChannels.requestClose).toBe('cmm:window:request-close');
     expect(cmmWindowLifecycleChannels.respondClose).toBe('cmm:window:respond-close');
 
@@ -145,6 +146,37 @@ describe('Opportunity IPC contracts', () => {
     expect(
       validateIpcOutput(cmmIpcContracts.saveBaseCapabilityMatrix, baseCapabilityMatrix),
     ).toEqual(baseCapabilityMatrix);
+    expect(
+      validateIpcInput(cmmIpcContracts.exportBaseCapabilityMatrix, {
+        opportunityId: 'opportunity-1',
+      }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.exportBaseCapabilityMatrix, {
+        status: 'exported',
+        filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      }),
+    ).toEqual({
+      status: 'exported',
+      filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.exportBaseCapabilityMatrix, {
+        status: 'canceled',
+        filename: null,
+      }),
+    ).toEqual({
+      status: 'canceled',
+      filename: null,
+    });
+    expect(() =>
+      validateIpcOutput(cmmIpcContracts.exportBaseCapabilityMatrix, {
+        status: 'exported',
+        filename: null,
+      }),
+    ).toThrow();
     expect(validateIpcOutput(cmmIpcContracts.archiveOpportunity, opportunity)).toEqual(opportunity);
     expect(validateIpcOutput(cmmIpcContracts.restoreArchivedOpportunity, opportunity)).toEqual(
       opportunity,

--- a/packages/workbook/package.json
+++ b/packages/workbook/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@cmm/workbook",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "check": "biome check .",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@cmm/typescript-config": "workspace:*",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.4"
+  },
+  "dependencies": {
+    "@cmm/domain": "workspace:*",
+    "exceljs": "^4.4.0"
+  }
+}

--- a/packages/workbook/src/base-capability-matrix-workbook.test.ts
+++ b/packages/workbook/src/base-capability-matrix-workbook.test.ts
@@ -1,0 +1,168 @@
+import ExcelJS from 'exceljs';
+import { describe, expect, it } from 'vitest';
+import { buildBaseCapabilityMatrixWorkbook, parseMemberResponseWorkbook } from './index';
+
+type ProtectedWorksheetModel = ExcelJS.WorksheetModel & {
+  sheetProtection?: {
+    sheet?: boolean;
+  };
+};
+
+const buildWorkbook = () =>
+  buildBaseCapabilityMatrixWorkbook({
+    opportunity: {
+      id: 'opportunity-1',
+      name: 'Arctic Radar Upgrade',
+      solicitationNumber: 'RFP-2026-17',
+      issuingAgency: 'Naval Systems Command',
+      description: null,
+      createdAt: '2026-05-01T09:00:00.000Z',
+      updatedAt: '2026-05-01T09:05:00.000Z',
+      lastOpenedAt: null,
+      archivedAt: null,
+    },
+    exportTimestamp: '2026-05-02T10:00:00.000Z',
+    requirements: [
+      {
+        id: 'requirement-1',
+        text: 'Provide secure hosting',
+        level: 1,
+        position: 0,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-2',
+        text: 'Operate help desk',
+        level: 2,
+        position: 1,
+        retiredAt: null,
+      },
+      {
+        id: 'requirement-retired',
+        text: 'Retired draft row',
+        level: 1,
+        position: 2,
+        retiredAt: '2026-05-01T10:00:00.000Z',
+      },
+      {
+        id: 'requirement-blank',
+        text: '   ',
+        level: 1,
+        position: 3,
+        retiredAt: null,
+      },
+    ],
+  });
+
+describe('Base Capability Matrix workbook export', () => {
+  it('builds a protected CMM-authored workbook with hidden metadata and editable response fields', async () => {
+    const buffer = await buildWorkbook();
+    const workbook = new ExcelJS.Workbook();
+    const workbookBuffer = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
+    await workbook.xlsx.load(workbookBuffer);
+
+    const matrixSheet = workbook.getWorksheet('Base Capability Matrix');
+    const metadataSheet = workbook.getWorksheet('CMM Metadata');
+    expect(matrixSheet).toBeDefined();
+    expect(metadataSheet).toBeDefined();
+    if (!matrixSheet || !metadataSheet) {
+      throw new Error('Expected workbook sheets to exist.');
+    }
+    expect(metadataSheet?.state).toBe('hidden');
+
+    expect(metadataSheet?.getCell('A1').value).toBe('workbookFormatVersion');
+    expect(metadataSheet?.getCell('B1').value).toBe('1');
+    expect(metadataSheet?.getCell('A2').value).toBe('opportunityId');
+    expect(metadataSheet?.getCell('B2').value).toBe('opportunity-1');
+    expect(metadataSheet?.getCell('A3').value).toBe('exportTimestamp');
+    expect(metadataSheet?.getCell('B3').value).toBe('2026-05-02T10:00:00.000Z');
+    expect(metadataSheet?.getCell('A5').value).toBe('requirementId');
+    expect(metadataSheet?.getCell('B5').value).toBe('requirementNumber');
+    expect(metadataSheet?.getCell('A6').value).toBe('requirement-1');
+    expect(metadataSheet?.getCell('B6').value).toBe('1');
+    expect(metadataSheet?.getCell('A7').value).toBe('requirement-2');
+    expect(metadataSheet?.getCell('B7').value).toBe('1.1');
+
+    expect(matrixSheet?.getCell('A1').value).toBe('Opportunity');
+    expect(matrixSheet?.getCell('B1').value).toBe('Arctic Radar Upgrade');
+    expect(matrixSheet?.getCell('A2').value).toBe('Solicitation Number');
+    expect(matrixSheet?.getCell('B2').value).toBe('RFP-2026-17');
+    expect(matrixSheet?.getCell('A3').value).toBe('Issuing Agency');
+    expect(matrixSheet?.getCell('B3').value).toBe('Naval Systems Command');
+    expect(matrixSheet?.getCell('A4').value).toBe('Potential Consortium Member');
+    expect(matrixSheet?.getCell('B4').protection?.locked).toBe(false);
+
+    expect(matrixSheet?.getCell('A6').value).toBe('Capability Score');
+    expect(matrixSheet?.getCell('B6').value).toContain('0');
+    expect(matrixSheet?.getCell('B6').value).toContain('3');
+    expect(
+      (matrixSheet?.model as ProtectedWorksheetModel | undefined)?.sheetProtection?.sheet,
+    ).toBe(true);
+
+    expect(matrixSheet?.getRow(8).values).toEqual([
+      undefined,
+      'Requirement #',
+      'Requirement',
+      'Capability Score',
+      'Past Performance Reference',
+      'Response Comment',
+      'CMM Requirement ID',
+    ]);
+    expect(matrixSheet?.getColumn(6).hidden).toBe(true);
+
+    expect(matrixSheet?.getCell('A9').value).toBe('1');
+    expect(matrixSheet?.getCell('B9').value).toBe('Provide secure hosting');
+    expect(matrixSheet?.getCell('F9').value).toBe('requirement-1');
+    expect(matrixSheet?.getCell('A10').value).toBe('1.1');
+    expect(matrixSheet?.getCell('B10').value).toBe('Operate help desk');
+    expect(matrixSheet?.getCell('F10').value).toBe('requirement-2');
+    expect(matrixSheet?.getCell('A11').value).toBeNull();
+
+    expect(matrixSheet?.getCell('A9').protection?.locked).not.toBe(false);
+    expect(matrixSheet?.getCell('B9').protection?.locked).not.toBe(false);
+    expect(matrixSheet?.getCell('F9').protection?.locked).not.toBe(false);
+    expect(matrixSheet?.getCell('C9').protection?.locked).toBe(false);
+    expect(matrixSheet?.getCell('D9').protection?.locked).toBe(false);
+    expect(matrixSheet?.getCell('E9').protection?.locked).toBe(false);
+    expect(matrixSheet?.getCell('D9').alignment?.wrapText).toBe(true);
+    expect(matrixSheet?.getCell('E9').alignment?.wrapText).toBe(true);
+    expect(matrixSheet?.getCell('C9').dataValidation).toMatchObject({
+      type: 'list',
+      allowBlank: true,
+      formulae: ['"0,1,2,3"'],
+    });
+
+    matrixSheet.getCell('B4').value = 'Polar Systems LLC';
+    matrixSheet.getCell('C9').value = 3;
+    matrixSheet.getCell('D9').value = 'Hosted IL5 workloads\nSupported SOC operations';
+    matrixSheet.getCell('E9').value = 'Prime experience\nAvailable immediately';
+
+    const roundTripBuffer = await workbook.xlsx.writeBuffer();
+    await expect(parseMemberResponseWorkbook(new Uint8Array(roundTripBuffer))).resolves.toEqual({
+      metadata: {
+        workbookFormatVersion: '1',
+        opportunityId: 'opportunity-1',
+        exportTimestamp: '2026-05-02T10:00:00.000Z',
+      },
+      memberName: 'Polar Systems LLC',
+      rows: [
+        {
+          requirementId: 'requirement-1',
+          requirementNumber: '1',
+          requirementText: 'Provide secure hosting',
+          capabilityScore: 3,
+          pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+          responseComment: 'Prime experience\nAvailable immediately',
+        },
+        {
+          requirementId: 'requirement-2',
+          requirementNumber: '1.1',
+          requirementText: 'Operate help desk',
+          capabilityScore: null,
+          pastPerformanceReference: '',
+          responseComment: '',
+        },
+      ],
+    });
+  });
+});

--- a/packages/workbook/src/index.ts
+++ b/packages/workbook/src/index.ts
@@ -1,0 +1,244 @@
+import {
+  computeRequirementNumbers,
+  type IsoDateTime,
+  type Opportunity,
+  type Requirement,
+} from '@cmm/domain';
+import ExcelJS from 'exceljs';
+
+const workbookFormatVersion = '1';
+const matrixSheetName = 'Base Capability Matrix';
+const metadataSheetName = 'CMM Metadata';
+const responseStartRow = 9;
+
+export type BaseCapabilityMatrixWorkbookRequirement = Requirement;
+
+export type BuildBaseCapabilityMatrixWorkbookInput = {
+  opportunity: Opportunity;
+  exportTimestamp: IsoDateTime;
+  requirements: BaseCapabilityMatrixWorkbookRequirement[];
+};
+
+export type ParsedMemberResponseWorkbook = {
+  metadata: {
+    workbookFormatVersion: string;
+    opportunityId: string;
+    exportTimestamp: IsoDateTime;
+  };
+  memberName: string;
+  rows: {
+    requirementId: string;
+    requirementNumber: string;
+    requirementText: string;
+    capabilityScore: 0 | 1 | 2 | 3 | null;
+    pastPerformanceReference: string;
+    responseComment: string;
+  }[];
+};
+
+export const buildBaseCapabilityMatrixWorkbook = (
+  input: BuildBaseCapabilityMatrixWorkbookInput,
+): Promise<Uint8Array> => buildWorkbook(input);
+
+const buildWorkbook = async (
+  input: BuildBaseCapabilityMatrixWorkbookInput,
+): Promise<Uint8Array> => {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'CMM';
+  workbook.created = new Date(input.exportTimestamp);
+  workbook.modified = new Date(input.exportTimestamp);
+
+  const matrixSheet = workbook.addWorksheet(matrixSheetName, {
+    views: [{ state: 'frozen', xSplit: 2, ySplit: 8 }],
+  });
+  const metadataSheet = workbook.addWorksheet(metadataSheetName);
+  metadataSheet.state = 'hidden';
+
+  writeMetadataSheet(metadataSheet, input);
+  await writeMatrixSheet(matrixSheet, input);
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new Uint8Array(buffer);
+};
+
+export const parseMemberResponseWorkbook = async (
+  buffer: Uint8Array,
+): Promise<ParsedMemberResponseWorkbook> => {
+  const workbook = new ExcelJS.Workbook();
+  const workbookBuffer = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
+  await workbook.xlsx.load(workbookBuffer);
+
+  const matrixSheet = workbook.getWorksheet(matrixSheetName);
+  const metadataSheet = workbook.getWorksheet(metadataSheetName);
+  if (!matrixSheet || !metadataSheet) {
+    throw new Error('CMM workbook sheets are missing.');
+  }
+
+  const rows: ParsedMemberResponseWorkbook['rows'] = [];
+  for (let rowNumber = responseStartRow; rowNumber <= matrixSheet.rowCount; rowNumber += 1) {
+    const row = matrixSheet.getRow(rowNumber);
+    const requirementId = cellValueToText(row.getCell(6).value);
+    const requirementNumber = cellValueToText(row.getCell(1).value);
+    const requirementText = cellValueToText(row.getCell(2).value);
+    if (!requirementId && !requirementNumber && !requirementText) {
+      continue;
+    }
+
+    rows.push({
+      requirementId,
+      requirementNumber,
+      requirementText,
+      capabilityScore: parseCapabilityScore(row.getCell(3).value),
+      pastPerformanceReference: cellValueToText(row.getCell(4).value),
+      responseComment: cellValueToText(row.getCell(5).value),
+    });
+  }
+
+  return {
+    metadata: {
+      workbookFormatVersion: cellValueToText(metadataSheet.getCell('B1').value),
+      opportunityId: cellValueToText(metadataSheet.getCell('B2').value),
+      exportTimestamp: cellValueToText(metadataSheet.getCell('B3').value),
+    },
+    memberName: cellValueToText(matrixSheet.getCell('B4').value),
+    rows,
+  };
+};
+
+const writeMetadataSheet = (
+  sheet: ExcelJS.Worksheet,
+  input: BuildBaseCapabilityMatrixWorkbookInput,
+): void => {
+  sheet.getCell('A1').value = 'workbookFormatVersion';
+  sheet.getCell('B1').value = workbookFormatVersion;
+  sheet.getCell('A2').value = 'opportunityId';
+  sheet.getCell('B2').value = input.opportunity.id;
+  sheet.getCell('A3').value = 'exportTimestamp';
+  sheet.getCell('B3').value = input.exportTimestamp;
+
+  const exportedRequirements = getExportedRequirements(input.requirements);
+  sheet.getCell('A5').value = 'requirementId';
+  sheet.getCell('B5').value = 'requirementNumber';
+  exportedRequirements.forEach(({ requirement, displayNumber }, index) => {
+    const row = sheet.getRow(6 + index);
+    row.getCell(1).value = requirement.id;
+    row.getCell(2).value = displayNumber;
+  });
+};
+
+const writeMatrixSheet = (
+  sheet: ExcelJS.Worksheet,
+  input: BuildBaseCapabilityMatrixWorkbookInput,
+): Promise<void> => {
+  sheet.columns = [
+    { key: 'requirementNumber', width: 18 },
+    { key: 'requirementText', width: 48 },
+    { key: 'capabilityScore', width: 18 },
+    { key: 'pastPerformanceReference', width: 34 },
+    { key: 'responseComment', width: 34 },
+    { key: 'requirementId', width: 1, hidden: true },
+  ];
+
+  sheet.getCell('A1').value = 'Opportunity';
+  sheet.getCell('B1').value = input.opportunity.name;
+  sheet.getCell('A2').value = 'Solicitation Number';
+  sheet.getCell('B2').value = input.opportunity.solicitationNumber ?? '';
+  sheet.getCell('A3').value = 'Issuing Agency';
+  sheet.getCell('B3').value = input.opportunity.issuingAgency ?? '';
+  sheet.getCell('A4').value = 'Potential Consortium Member';
+  sheet.getCell('B4').value = '';
+  unlockCell(sheet.getCell('B4'));
+
+  sheet.getCell('A6').value = 'Capability Score';
+  sheet.getCell('B6').value = '0 = no capability, 1 = limited, 2 = partial, 3 = strong';
+
+  const header = sheet.getRow(8);
+  header.getCell(1).value = 'Requirement #';
+  header.getCell(2).value = 'Requirement';
+  header.getCell(3).value = 'Capability Score';
+  header.getCell(4).value = 'Past Performance Reference';
+  header.getCell(5).value = 'Response Comment';
+  header.getCell(6).value = 'CMM Requirement ID';
+  header.font = { bold: true };
+
+  const exportedRequirements = getExportedRequirements(input.requirements);
+  exportedRequirements.forEach(({ requirement, displayNumber }, index) => {
+    const row = sheet.getRow(responseStartRow + index);
+    row.getCell(1).value = displayNumber;
+    row.getCell(2).value = requirement.text.trim();
+    row.getCell(3).value = null;
+    row.getCell(4).value = '';
+    row.getCell(5).value = '';
+    row.getCell(6).value = requirement.id;
+
+    unlockCell(row.getCell(3));
+    unlockCell(row.getCell(4));
+    unlockCell(row.getCell(5));
+    row.getCell(3).dataValidation = {
+      type: 'list',
+      allowBlank: true,
+      formulae: ['"0,1,2,3"'],
+      showErrorMessage: true,
+      errorTitle: 'Invalid Capability Score',
+      error: 'Use 0, 1, 2, or 3.',
+    };
+    row.getCell(4).alignment = { wrapText: true, vertical: 'top' };
+    row.getCell(5).alignment = { wrapText: true, vertical: 'top' };
+  });
+
+  return sheet.protect('', {
+    selectLockedCells: true,
+    selectUnlockedCells: true,
+  });
+};
+
+const getExportedRequirements = (requirements: Requirement[]) =>
+  computeRequirementNumbers(
+    requirements.filter(
+      (requirement) => requirement.retiredAt === null && requirement.text.trim().length > 0,
+    ),
+  );
+
+const unlockCell = (cell: ExcelJS.Cell): void => {
+  cell.protection = { locked: false };
+};
+
+const cellValueToText = (value: ExcelJS.CellValue): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if ('richText' in value) {
+    return value.richText.map((part) => part.text).join('');
+  }
+
+  if ('text' in value) {
+    return value.text;
+  }
+
+  if ('result' in value) {
+    return cellValueToText(value.result);
+  }
+
+  return '';
+};
+
+const parseCapabilityScore = (value: ExcelJS.CellValue): 0 | 1 | 2 | 3 | null => {
+  const text = cellValueToText(value).trim();
+  if (text !== '0' && text !== '1' && text !== '2' && text !== '3') {
+    return null;
+  }
+  return Number(text) as 0 | 1 | 2 | 3;
+};

--- a/packages/workbook/tsconfig.json
+++ b/packages/workbook/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@cmm/typescript-config/library.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@cmm/ui':
         specifier: workspace:*
         version: link:../../packages/cmm-ui
+      '@cmm/workbook':
+        specifier: workspace:*
+        version: link:../../packages/workbook
       electron:
         specifier: ^41.2.1
         version: 41.2.1
@@ -304,6 +307,25 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/workbook:
+    dependencies:
+      '@cmm/domain':
+        specifier: workspace:*
+        version: link:../domain
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
+    devDependencies:
+      '@cmm/typescript-config':
+        specifier: workspace:*
+        version: link:../cmm-typescript-config
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.2.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.2.0)(esbuild@0.28.0)(terser@5.46.0)(yaml@2.8.2))
 
 packages:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "./packages/cmm-ui" },
     { "path": "./packages/domain" },
     { "path": "./packages/persistence-sqlite" },
+    { "path": "./packages/workbook" },
     { "path": "./packages/ui" },
     { "path": "./packages/types" }
   ]


### PR DESCRIPTION
## Summary

- Add an ExcelJS-backed `@cmm/workbook` package for protected CMM-authored Base Capability Matrix workbook export and parsing.
- Add the application export use case plus typed IPC, preload, and Electron main save-dialog/file-write wiring.
- Add the renderer `Export Workbook` action guarded by the existing Base Capability Matrix flush flow.

Closes #11

## Validation

- `pnpm --filter @cmm/workbook test`
- `pnpm --filter @cmm/application test`
- `pnpm --filter @cmm/contracts test`
- `pnpm --filter @app/desktop test:unit -- --runInBand`
- `pnpm --filter @cmm/workbook typecheck`
- `pnpm --filter @cmm/application typecheck`
- `pnpm --filter @app/desktop typecheck`
- `pnpm check`
- `pnpm --filter @app/desktop build`

The commit hook also reran workspace format, lint, check, and typecheck successfully.
