### PR TITLE
Add Base Capability Matrix export preflight options

### DIFF
--- a/apps/desktop/electron/base-capability-matrix-export.test.ts
+++ b/apps/desktop/electron/base-capability-matrix-export.test.ts
@@ -35,13 +35,19 @@ describe('Base Capability Matrix export file service', () => {
     });
 
     await expect(
-      exportFileService.exportBaseCapabilityMatrix({ opportunityId: 'opportunity-1' }),
+      exportFileService.exportBaseCapabilityMatrix({
+        opportunityId: 'opportunity-1',
+        includeBlankRequirements: false,
+        includeRetiredRequirements: false,
+      }),
     ).resolves.toEqual({
       status: 'exported',
       filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
     });
     expect(service.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
       opportunityId: 'opportunity-1',
+      includeBlankRequirements: false,
+      includeRetiredRequirements: false,
     });
     expect(writeFile).toHaveBeenCalledWith(
       '/tmp/Arctic Radar Upgrade - Base Capability Matrix.xlsx',
@@ -61,7 +67,11 @@ describe('Base Capability Matrix export file service', () => {
     });
 
     await expect(
-      exportFileService.exportBaseCapabilityMatrix({ opportunityId: 'opportunity-1' }),
+      exportFileService.exportBaseCapabilityMatrix({
+        opportunityId: 'opportunity-1',
+        includeBlankRequirements: false,
+        includeRetiredRequirements: false,
+      }),
     ).resolves.toEqual({
       status: 'canceled',
       filename: null,

--- a/apps/desktop/electron/cmm-ipc.test.ts
+++ b/apps/desktop/electron/cmm-ipc.test.ts
@@ -143,12 +143,23 @@ describe('registerCmmIpcHandlers', () => {
     await expect(exportMatrixHandler?.({}, { opportunityId: '' })).rejects.toThrow(
       'Opportunity ID is required.',
     );
-    await expect(exportMatrixHandler?.({}, { opportunityId: 'opportunity-1' })).resolves.toEqual({
+    await expect(
+      exportMatrixHandler?.(
+        {},
+        {
+          opportunityId: 'opportunity-1',
+          includeBlankRequirements: true,
+          includeRetiredRequirements: false,
+        },
+      ),
+    ).resolves.toEqual({
       status: 'exported',
       filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
     });
     expect(baseCapabilityMatrixExportFileService.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
       opportunityId: 'opportunity-1',
+      includeBlankRequirements: true,
+      includeRetiredRequirements: false,
     });
 
     const hardDeleteHandler = ipcMain.handlers.get(

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -690,11 +690,205 @@ describe('App', () => {
     );
     expect(api.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
       opportunityId: activeOpportunity.id,
+      includeBlankRequirements: false,
+      includeRetiredRequirements: false,
     });
     expect(calls).toEqual(['save', 'export']);
     expect(
       await screen.findByText('Exported Arctic Radar Upgrade - Base Capability Matrix.xlsx'),
     ).toBeVisible();
+  });
+
+  it('shows warnings and defaults to excluding blank and retired Requirements before export', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-blank',
+          text: '   ',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-retired',
+          text: 'Retired draft row',
+          level: 1,
+          position: 2,
+          retiredAt: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      exportBaseCapabilityMatrix: vi.fn(async () => ({
+        status: 'exported' as const,
+        filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByRole('button', { name: 'Export Workbook' }));
+
+    expect(
+      await screen.findByText(
+        'Blank Requirements may send draft or empty rows to potential consortium members.',
+      ),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        'Retired Requirements may reintroduce historical content into the sent baseline.',
+      ),
+    ).toBeVisible();
+    expect(api.exportBaseCapabilityMatrix).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Continue Export' }));
+
+    expect(api.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      includeBlankRequirements: false,
+      includeRetiredRequirements: false,
+    });
+  });
+
+  it('flushes dirty Base Capability Matrix edits before showing export preflight', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    };
+    const calls: string[] = [];
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      saveBaseCapabilityMatrix: vi.fn(async (matrix) => {
+        calls.push('save');
+        return {
+          ...matrix,
+          revision: matrix.revision + 1,
+        };
+      }),
+      exportBaseCapabilityMatrix: vi.fn(async () => {
+        calls.push('export');
+        return {
+          status: 'exported' as const,
+          filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+        };
+      }),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.clear(screen.getByLabelText('Requirement 1 text'));
+    await user.click(screen.getByRole('button', { name: 'Export Workbook' }));
+
+    await waitFor(() =>
+      expect(api.saveBaseCapabilityMatrix).toHaveBeenCalledWith({
+        opportunityId: activeOpportunity.id,
+        revision: 1,
+        requirements: [
+          {
+            id: 'requirement-1',
+            text: '',
+            level: 1,
+            position: 0,
+            retiredAt: null,
+          },
+        ],
+      }),
+    );
+    expect(
+      await screen.findByText(
+        'Blank Requirements may send draft or empty rows to potential consortium members.',
+      ),
+    ).toBeVisible();
+    expect(api.exportBaseCapabilityMatrix).not.toHaveBeenCalled();
+    expect(calls).toEqual(['save']);
+  });
+
+  it('exports explicit preflight choices after the user sees the warnings', async () => {
+    const baseCapabilityMatrix: BaseCapabilityMatrixDto = {
+      opportunityId: activeOpportunity.id,
+      revision: 1,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-blank',
+          text: '',
+          level: 1,
+          position: 1,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-retired',
+          text: 'Retired draft row',
+          level: 1,
+          position: 2,
+          retiredAt: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+    };
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix,
+      })),
+      exportBaseCapabilityMatrix: vi.fn(async () => ({
+        status: 'exported' as const,
+        filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByRole('button', { name: 'Export Workbook' }));
+    await screen.findByText(
+      'Blank Requirements may send draft or empty rows to potential consortium members.',
+    );
+
+    await user.click(screen.getByLabelText('Include blank Requirements'));
+    await user.click(screen.getByLabelText('Include retired Requirements'));
+    await user.click(screen.getByRole('button', { name: 'Continue Export' }));
+
+    expect(api.exportBaseCapabilityMatrix).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+      includeBlankRequirements: true,
+      includeRetiredRequirements: true,
+    });
   });
 
   it('inserts a new active Requirement from Enter and focuses the new text field', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,6 +27,14 @@ type MatrixFlushResult = 'clean' | 'saved' | 'dirty' | 'failed' | 'conflicted';
 type MatrixFlushOptions = {
   force?: boolean;
 };
+type BaseCapabilityMatrixExportChoices = {
+  includeBlankRequirements: boolean;
+  includeRetiredRequirements: boolean;
+};
+type ExportPreflightState = BaseCapabilityMatrixExportChoices & {
+  blankRequirementCount: number;
+  retiredRequirementCount: number;
+};
 
 type NumberedRequirement = {
   requirement: RequirementDto;
@@ -125,6 +133,30 @@ const getErrorMessage = (unknownError: unknown, fallback: string): string =>
 const isBaseCapabilityMatrixRevisionConflict = (message: string): boolean =>
   message.includes('changed since') || message.includes('revision conflict');
 
+const defaultExportChoices: BaseCapabilityMatrixExportChoices = {
+  includeBlankRequirements: false,
+  includeRetiredRequirements: false,
+};
+
+const getExportPreflightState = (matrix: BaseCapabilityMatrixDto): ExportPreflightState | null => {
+  const blankRequirementCount = matrix.requirements.filter(
+    (requirement) => requirement.text.trim().length === 0,
+  ).length;
+  const retiredRequirementCount = matrix.requirements.filter(
+    (requirement) => requirement.retiredAt !== null,
+  ).length;
+
+  if (blankRequirementCount === 0 && retiredRequirementCount === 0) {
+    return null;
+  }
+
+  return {
+    ...defaultExportChoices,
+    blankRequirementCount,
+    retiredRequirementCount,
+  };
+};
+
 function App(): React.JSX.Element {
   const [opportunities, setOpportunities] = useState<OpportunityDto[]>([]);
   const [archivedOpportunities, setArchivedOpportunities] = useState<OpportunityDto[]>([]);
@@ -132,6 +164,7 @@ function App(): React.JSX.Element {
   const [openedOpportunity, setOpenedOpportunity] = useState<OpenedOpportunityState | null>(null);
   const [showRetiredRequirements, setShowRetiredRequirements] = useState(false);
   const [matrixSaveState, setMatrixSaveState] = useState<MatrixSaveState>('idle');
+  const [exportPreflight, setExportPreflight] = useState<ExportPreflightState | null>(null);
   const [pendingRequirementFocusId, setPendingRequirementFocusId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
@@ -325,6 +358,7 @@ function App(): React.JSX.Element {
       lifecycle: listMode,
     });
     setShowRetiredRequirements(false);
+    setExportPreflight(null);
     draftVersionRef.current = 0;
     setTrackedMatrixSaveState('idle');
     await refreshOpportunities();
@@ -338,6 +372,7 @@ function App(): React.JSX.Element {
     }
 
     draftVersionRef.current += 1;
+    setExportPreflight(null);
     setOpenedOpportunity((current) => {
       if (!current || current.lifecycle === 'archived') {
         return current;
@@ -626,6 +661,7 @@ function App(): React.JSX.Element {
       });
       draftVersionRef.current = 0;
       setShowRetiredRequirements(false);
+      setExportPreflight(null);
       setTrackedMatrixSaveState('idle');
       await refreshOpportunities();
     } catch (unknownError) {
@@ -684,15 +720,60 @@ function App(): React.JSX.Element {
 
     setError(null);
     setNotice(null);
+    setExportPreflight(null);
     try {
       if (!(await flushBaseCapabilityMatrixBeforeProceeding())) {
         return;
       }
 
-      const result = await window.cmmApi.exportBaseCapabilityMatrix({
-        opportunityId: openedOpportunity.opportunity.id,
+      const current = openedOpportunityRef.current;
+      if (!current || current.lifecycle !== 'active') {
+        return;
+      }
+
+      const preflight = getExportPreflightState(current.baseCapabilityMatrix);
+      if (preflight) {
+        setExportPreflight(preflight);
+        return;
+      }
+
+      await exportBaseCapabilityMatrix(defaultExportChoices);
+    } catch (unknownError) {
+      setError(getErrorMessage(unknownError, 'Unable to export Base Capability Matrix.'));
+    }
+  };
+
+  const exportBaseCapabilityMatrix = async (exportChoices: BaseCapabilityMatrixExportChoices) => {
+    const current = openedOpportunityRef.current;
+    if (!current || current.lifecycle !== 'active') {
+      return;
+    }
+
+    const result = await window.cmmApi.exportBaseCapabilityMatrix({
+      opportunityId: current.opportunity.id,
+      ...exportChoices,
+    });
+    setNotice(result.status === 'exported' ? `Exported ${result.filename}` : 'Export canceled.');
+  };
+
+  const confirmExportPreflight = async () => {
+    if (!exportPreflight) {
+      return;
+    }
+
+    setError(null);
+    setNotice(null);
+    try {
+      if (!(await flushBaseCapabilityMatrixBeforeProceeding())) {
+        return;
+      }
+
+      const { includeBlankRequirements, includeRetiredRequirements } = exportPreflight;
+      setExportPreflight(null);
+      await exportBaseCapabilityMatrix({
+        includeBlankRequirements,
+        includeRetiredRequirements,
       });
-      setNotice(result.status === 'exported' ? `Exported ${result.filename}` : 'Export canceled.');
     } catch (unknownError) {
       setError(getErrorMessage(unknownError, 'Unable to export Base Capability Matrix.'));
     }
@@ -969,6 +1050,68 @@ function App(): React.JSX.Element {
                     </div>
                   ) : null}
                   {notice ? <span className="matrix-save-status">{notice}</span> : null}
+                  {exportPreflight ? (
+                    <section aria-label="Export preflight choices" className="export-preflight">
+                      {exportPreflight.blankRequirementCount > 0 ? (
+                        <div className="export-preflight-choice">
+                          <label className="export-preflight-option">
+                            <input
+                              checked={exportPreflight.includeBlankRequirements}
+                              type="checkbox"
+                              onChange={(event) =>
+                                setExportPreflight((current) =>
+                                  current
+                                    ? {
+                                        ...current,
+                                        includeBlankRequirements: event.target.checked,
+                                      }
+                                    : current,
+                                )
+                              }
+                            />
+                            <span>Include blank Requirements</span>
+                          </label>
+                          <p>
+                            Blank Requirements may send draft or empty rows to potential consortium
+                            members.
+                          </p>
+                        </div>
+                      ) : null}
+                      {exportPreflight.retiredRequirementCount > 0 ? (
+                        <div className="export-preflight-choice">
+                          <label className="export-preflight-option">
+                            <input
+                              checked={exportPreflight.includeRetiredRequirements}
+                              type="checkbox"
+                              onChange={(event) =>
+                                setExportPreflight((current) =>
+                                  current
+                                    ? {
+                                        ...current,
+                                        includeRetiredRequirements: event.target.checked,
+                                      }
+                                    : current,
+                                )
+                              }
+                            />
+                            <span>Include retired Requirements</span>
+                          </label>
+                          <p>
+                            Retired Requirements may reintroduce historical content into the sent
+                            baseline.
+                          </p>
+                        </div>
+                      ) : null}
+                      <div className="export-preflight-actions">
+                        <Button variant="primary" onClick={() => void confirmExportPreflight()}>
+                          Continue Export
+                        </Button>
+                        <Button variant="ghost" onClick={() => setExportPreflight(null)}>
+                          Cancel Export
+                        </Button>
+                      </div>
+                    </section>
+                  ) : null}
                 </div>
               ) : null}
 

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -303,6 +303,48 @@ textarea {
   font-weight: 750;
 }
 
+.export-preflight {
+  display: grid;
+  flex-basis: 100%;
+  gap: 12px;
+  border: 1px solid #c8d2c5;
+  background: #f7faf4;
+  color: #1c2228;
+  padding: 14px;
+}
+
+.export-preflight-choice {
+  display: grid;
+  gap: 4px;
+}
+
+.export-preflight-choice p {
+  margin: 0;
+  color: #6f4f12;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.export-preflight-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.export-preflight-option input {
+  width: 16px;
+  height: 16px;
+  accent-color: #315f68;
+}
+
+.export-preflight-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .matrix-outline {
   display: grid;
   gap: 8px;

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -62,9 +62,14 @@ export type SaveBaseCapabilityMatrixInput = {
   requirements: Requirement[];
 };
 
+export type BaseCapabilityMatrixExportChoices = {
+  includeBlankRequirements: boolean;
+  includeRetiredRequirements: boolean;
+};
+
 export type ExportBaseCapabilityMatrixInput = {
   opportunityId: OpportunityId;
-};
+} & BaseCapabilityMatrixExportChoices;
 
 export type OpenOpportunityResult = {
   opportunity: Opportunity;
@@ -75,6 +80,7 @@ export type BuildBaseCapabilityMatrixWorkbookInput = {
   opportunity: Opportunity;
   exportTimestamp: IsoDateTime;
   requirements: Requirement[];
+  exportChoices: BaseCapabilityMatrixExportChoices;
 };
 
 export type BaseCapabilityMatrixWorkbookBuilder = {
@@ -218,6 +224,10 @@ export const createOpportunityService = ({
       opportunity,
       exportTimestamp,
       requirements: baseCapabilityMatrix.requirements,
+      exportChoices: {
+        includeBlankRequirements: input.includeBlankRequirements,
+        includeRetiredRequirements: input.includeRetiredRequirements,
+      },
     });
 
     return {

--- a/packages/application/src/opportunity-service.test.ts
+++ b/packages/application/src/opportunity-service.test.ts
@@ -426,7 +426,11 @@ describe('OpportunityService', () => {
     });
 
     await expect(
-      service.exportBaseCapabilityMatrix({ opportunityId: opportunity.id }),
+      service.exportBaseCapabilityMatrix({
+        opportunityId: opportunity.id,
+        includeBlankRequirements: false,
+        includeRetiredRequirements: false,
+      }),
     ).resolves.toEqual({
       workbook: new Uint8Array([1, 2, 3]),
       suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
@@ -437,8 +441,56 @@ describe('OpportunityService', () => {
         opportunity,
         exportTimestamp: '2026-05-02T10:00:00.000Z',
         requirements: saved.requirements,
+        exportChoices: {
+          includeBlankRequirements: false,
+          includeRetiredRequirements: false,
+        },
       },
     ]);
+  });
+
+  it('passes Base Capability Matrix export choices to the workbook builder', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const builtWorkbooks: BuildBaseCapabilityMatrixWorkbookInput[] = [];
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-02T10:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+      workbookBuilder: {
+        async buildBaseCapabilityMatrixWorkbook(input) {
+          builtWorkbooks.push(input);
+          return new Uint8Array([1, 2, 3]);
+        },
+      },
+    });
+
+    const opportunity = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    await service.exportBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      includeBlankRequirements: true,
+      includeRetiredRequirements: false,
+    });
+
+    expect(builtWorkbooks[0]).toMatchObject({
+      exportChoices: {
+        includeBlankRequirements: true,
+        includeRetiredRequirements: false,
+      },
+    });
   });
 
   it('hard-deletes an archived Opportunity', async () => {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,6 +28,11 @@ const opportunityIdInputSchema = z.object({
     .refine((value) => value.trim().length > 0, 'Opportunity ID is required.'),
 });
 
+const exportBaseCapabilityMatrixInputSchema = opportunityIdInputSchema.extend({
+  includeBlankRequirements: z.boolean(),
+  includeRetiredRequirements: z.boolean(),
+});
+
 const requirementSchema = z.object({
   id: z.string().min(1),
   text: z.string(),
@@ -79,7 +84,9 @@ export type OpenOpportunityIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type OpenOpportunityIpcOutput = z.infer<typeof openOpportunityOutputSchema>;
 export type OpportunityLifecycleIpcInput = z.infer<typeof opportunityIdInputSchema>;
 export type SaveBaseCapabilityMatrixIpcInput = z.infer<typeof baseCapabilityMatrixSchema>;
-export type ExportBaseCapabilityMatrixIpcInput = z.infer<typeof opportunityIdInputSchema>;
+export type ExportBaseCapabilityMatrixIpcInput = z.infer<
+  typeof exportBaseCapabilityMatrixInputSchema
+>;
 export type ExportBaseCapabilityMatrixIpcOutput = z.infer<
   typeof exportBaseCapabilityMatrixOutputSchema
 >;
@@ -132,7 +139,7 @@ export const cmmIpcContracts = {
   }),
   exportBaseCapabilityMatrix: defineContract({
     channel: 'cmm:base-matrices:export',
-    inputSchema: opportunityIdInputSchema,
+    inputSchema: exportBaseCapabilityMatrixInputSchema,
     outputSchema: exportBaseCapabilityMatrixOutputSchema,
   }),
   archiveOpportunity: defineContract({

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -149,9 +149,13 @@ describe('Opportunity IPC contracts', () => {
     expect(
       validateIpcInput(cmmIpcContracts.exportBaseCapabilityMatrix, {
         opportunityId: 'opportunity-1',
+        includeBlankRequirements: true,
+        includeRetiredRequirements: false,
       }),
     ).toEqual({
       opportunityId: 'opportunity-1',
+      includeBlankRequirements: true,
+      includeRetiredRequirements: false,
     });
     expect(
       validateIpcOutput(cmmIpcContracts.exportBaseCapabilityMatrix, {

--- a/packages/domain/src/base-capability-matrix.test.ts
+++ b/packages/domain/src/base-capability-matrix.test.ts
@@ -56,6 +56,25 @@ describe('Base Capability Matrix requirements', () => {
         displayNumber: '2',
       },
     ]);
+
+    expect(computeRequirementNumbers(requirements, { includeRetired: true })).toEqual([
+      {
+        requirement: requirements[0],
+        displayNumber: '1',
+      },
+      {
+        requirement: requirements[1],
+        displayNumber: '1.1',
+      },
+      {
+        requirement: requirements[2],
+        displayNumber: '1.2',
+      },
+      {
+        requirement: requirements[3],
+        displayNumber: '2',
+      },
+    ]);
   });
 
   it('preserves Requirement identity across text, order, level, and retirement edits', () => {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -40,6 +40,10 @@ export type RequirementNumber = {
   displayNumber: string;
 };
 
+export type RequirementNumberOptions = {
+  includeRetired?: boolean;
+};
+
 const orderRequirements = (requirements: Requirement[]): Requirement[] =>
   [...requirements].sort((left, right) => left.position - right.position);
 
@@ -73,10 +77,13 @@ export const normalizeOptionalText = (value: string | null | undefined): string 
   return normalized.length > 0 ? normalized : null;
 };
 
-export const computeRequirementNumbers = (requirements: Requirement[]): RequirementNumber[] => {
+export const computeRequirementNumbers = (
+  requirements: Requirement[],
+  options: RequirementNumberOptions = {},
+): RequirementNumber[] => {
   const counters: number[] = [];
   return orderRequirements(requirements)
-    .filter((requirement) => requirement.retiredAt === null)
+    .filter((requirement) => options.includeRetired || requirement.retiredAt === null)
     .map((requirement) => {
       const level = Math.max(1, requirement.level);
       counters.length = level;

--- a/packages/workbook/src/base-capability-matrix-workbook.test.ts
+++ b/packages/workbook/src/base-capability-matrix-workbook.test.ts
@@ -1,6 +1,10 @@
 import ExcelJS from 'exceljs';
 import { describe, expect, it } from 'vitest';
-import { buildBaseCapabilityMatrixWorkbook, parseMemberResponseWorkbook } from './index';
+import {
+  type BaseCapabilityMatrixExportChoices,
+  buildBaseCapabilityMatrixWorkbook,
+  parseMemberResponseWorkbook,
+} from './index';
 
 type ProtectedWorksheetModel = ExcelJS.WorksheetModel & {
   sheetProtection?: {
@@ -8,58 +12,73 @@ type ProtectedWorksheetModel = ExcelJS.WorksheetModel & {
   };
 };
 
-const buildWorkbook = () =>
-  buildBaseCapabilityMatrixWorkbook({
-    opportunity: {
-      id: 'opportunity-1',
-      name: 'Arctic Radar Upgrade',
-      solicitationNumber: 'RFP-2026-17',
-      issuingAgency: 'Naval Systems Command',
-      description: null,
-      createdAt: '2026-05-01T09:00:00.000Z',
-      updatedAt: '2026-05-01T09:05:00.000Z',
-      lastOpenedAt: null,
-      archivedAt: null,
+const defaultExportChoices: BaseCapabilityMatrixExportChoices = {
+  includeBlankRequirements: false,
+  includeRetiredRequirements: false,
+};
+
+const workbookInput = {
+  opportunity: {
+    id: 'opportunity-1',
+    name: 'Arctic Radar Upgrade',
+    solicitationNumber: 'RFP-2026-17',
+    issuingAgency: 'Naval Systems Command',
+    description: null,
+    createdAt: '2026-05-01T09:00:00.000Z',
+    updatedAt: '2026-05-01T09:05:00.000Z',
+    lastOpenedAt: null,
+    archivedAt: null,
+  },
+  exportTimestamp: '2026-05-02T10:00:00.000Z',
+  requirements: [
+    {
+      id: 'requirement-1',
+      text: 'Provide secure hosting',
+      level: 1,
+      position: 0,
+      retiredAt: null,
     },
-    exportTimestamp: '2026-05-02T10:00:00.000Z',
-    requirements: [
-      {
-        id: 'requirement-1',
-        text: 'Provide secure hosting',
-        level: 1,
-        position: 0,
-        retiredAt: null,
-      },
-      {
-        id: 'requirement-2',
-        text: 'Operate help desk',
-        level: 2,
-        position: 1,
-        retiredAt: null,
-      },
-      {
-        id: 'requirement-retired',
-        text: 'Retired draft row',
-        level: 1,
-        position: 2,
-        retiredAt: '2026-05-01T10:00:00.000Z',
-      },
-      {
-        id: 'requirement-blank',
-        text: '   ',
-        level: 1,
-        position: 3,
-        retiredAt: null,
-      },
-    ],
+    {
+      id: 'requirement-2',
+      text: 'Operate help desk',
+      level: 2,
+      position: 1,
+      retiredAt: null,
+    },
+    {
+      id: 'requirement-retired',
+      text: 'Retired draft row',
+      level: 1,
+      position: 2,
+      retiredAt: '2026-05-01T10:00:00.000Z',
+    },
+    {
+      id: 'requirement-blank',
+      text: '   ',
+      level: 1,
+      position: 3,
+      retiredAt: null,
+    },
+  ],
+};
+
+const buildWorkbook = (exportChoices = defaultExportChoices) =>
+  buildBaseCapabilityMatrixWorkbook({
+    ...workbookInput,
+    exportChoices,
   });
+
+const loadWorkbook = async (buffer: Uint8Array): Promise<ExcelJS.Workbook> => {
+  const workbook = new ExcelJS.Workbook();
+  const workbookBuffer = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
+  await workbook.xlsx.load(workbookBuffer);
+  return workbook;
+};
 
 describe('Base Capability Matrix workbook export', () => {
   it('builds a protected CMM-authored workbook with hidden metadata and editable response fields', async () => {
     const buffer = await buildWorkbook();
-    const workbook = new ExcelJS.Workbook();
-    const workbookBuffer = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
-    await workbook.xlsx.load(workbookBuffer);
+    const workbook = await loadWorkbook(buffer);
 
     const matrixSheet = workbook.getWorksheet('Base Capability Matrix');
     const metadataSheet = workbook.getWorksheet('CMM Metadata');
@@ -164,5 +183,60 @@ describe('Base Capability Matrix workbook export', () => {
         },
       ],
     });
+  });
+
+  it('includes blank and retired Requirements when export choices opt into them', async () => {
+    const buffer = await buildWorkbook({
+      includeBlankRequirements: true,
+      includeRetiredRequirements: true,
+    });
+    const workbook = await loadWorkbook(buffer);
+
+    const matrixSheet = workbook.getWorksheet('Base Capability Matrix');
+    const metadataSheet = workbook.getWorksheet('CMM Metadata');
+    expect(matrixSheet).toBeDefined();
+    expect(metadataSheet).toBeDefined();
+    if (!matrixSheet || !metadataSheet) {
+      throw new Error('Expected workbook sheets to exist.');
+    }
+
+    expect(metadataSheet.getCell('A8').value).toBe('requirement-retired');
+    expect(metadataSheet.getCell('B8').value).toBe('2');
+    expect(metadataSheet.getCell('A9').value).toBe('requirement-blank');
+    expect(metadataSheet.getCell('B9').value).toBe('3');
+
+    expect(matrixSheet.getCell('A11').value).toBe('2');
+    expect(matrixSheet.getCell('B11').value).toBe('Retired draft row');
+    expect(matrixSheet.getCell('F11').value).toBe('requirement-retired');
+    expect(matrixSheet.getCell('A12').value).toBe('3');
+    expect(matrixSheet.getCell('B12').value).toBe('');
+    expect(matrixSheet.getCell('F12').value).toBe('requirement-blank');
+    expect(matrixSheet.getCell('A13').value).toBeNull();
+  });
+
+  it('applies blank and retired export choices independently', async () => {
+    const blankOnlyWorkbook = await parseMemberResponseWorkbook(
+      await buildWorkbook({
+        includeBlankRequirements: true,
+        includeRetiredRequirements: false,
+      }),
+    );
+    expect(blankOnlyWorkbook.rows.map((row) => row.requirementId)).toEqual([
+      'requirement-1',
+      'requirement-2',
+      'requirement-blank',
+    ]);
+
+    const retiredOnlyWorkbook = await parseMemberResponseWorkbook(
+      await buildWorkbook({
+        includeBlankRequirements: false,
+        includeRetiredRequirements: true,
+      }),
+    );
+    expect(retiredOnlyWorkbook.rows.map((row) => row.requirementId)).toEqual([
+      'requirement-1',
+      'requirement-2',
+      'requirement-retired',
+    ]);
   });
 });

--- a/packages/workbook/src/index.ts
+++ b/packages/workbook/src/index.ts
@@ -13,10 +13,16 @@ const responseStartRow = 9;
 
 export type BaseCapabilityMatrixWorkbookRequirement = Requirement;
 
+export type BaseCapabilityMatrixExportChoices = {
+  includeBlankRequirements?: boolean;
+  includeRetiredRequirements?: boolean;
+};
+
 export type BuildBaseCapabilityMatrixWorkbookInput = {
   opportunity: Opportunity;
   exportTimestamp: IsoDateTime;
   requirements: BaseCapabilityMatrixWorkbookRequirement[];
+  exportChoices?: BaseCapabilityMatrixExportChoices;
 };
 
 export type ParsedMemberResponseWorkbook = {
@@ -116,7 +122,7 @@ const writeMetadataSheet = (
   sheet.getCell('A3').value = 'exportTimestamp';
   sheet.getCell('B3').value = input.exportTimestamp;
 
-  const exportedRequirements = getExportedRequirements(input.requirements);
+  const exportedRequirements = getExportedRequirements(input.requirements, input.exportChoices);
   sheet.getCell('A5').value = 'requirementId';
   sheet.getCell('B5').value = 'requirementNumber';
   exportedRequirements.forEach(({ requirement, displayNumber }, index) => {
@@ -161,7 +167,7 @@ const writeMatrixSheet = (
   header.getCell(6).value = 'CMM Requirement ID';
   header.font = { bold: true };
 
-  const exportedRequirements = getExportedRequirements(input.requirements);
+  const exportedRequirements = getExportedRequirements(input.requirements, input.exportChoices);
   exportedRequirements.forEach(({ requirement, displayNumber }, index) => {
     const row = sheet.getRow(responseStartRow + index);
     row.getCell(1).value = displayNumber;
@@ -192,11 +198,22 @@ const writeMatrixSheet = (
   });
 };
 
-const getExportedRequirements = (requirements: Requirement[]) =>
+const getExportedRequirements = (
+  requirements: Requirement[],
+  exportChoices: BaseCapabilityMatrixExportChoices = {},
+) =>
   computeRequirementNumbers(
-    requirements.filter(
-      (requirement) => requirement.retiredAt === null && requirement.text.trim().length > 0,
-    ),
+    requirements.filter((requirement) => {
+      const isBlank = requirement.text.trim().length === 0;
+      const isRetired = requirement.retiredAt !== null;
+      return (
+        (!isBlank || exportChoices.includeBlankRequirements === true) &&
+        (!isRetired || exportChoices.includeRetiredRequirements === true)
+      );
+    }),
+    {
+      includeRetired: exportChoices.includeRetiredRequirements === true,
+    },
   );
 
 const unlockCell = (cell: ExcelJS.Cell): void => {


### PR DESCRIPTION
## Summary

- Add Base Capability Matrix export preflight choices in the desktop renderer for blank and retired Requirements.
- Default both choices to excluded, with warning copy before users can explicitly include either category.
- Thread explicit export choices through IPC contracts, application service, domain numbering, and workbook generation.
- Cover default exclusion, explicit inclusion, warning behavior, pending-save flush, IPC/application wiring, and workbook row contents.

## Validation

- `pnpm --filter @cmm/domain test`
- `pnpm --filter @cmm/workbook test`
- `pnpm --filter @cmm/application test`
- `pnpm --filter @cmm/contracts test`
- `pnpm --filter @app/desktop test:unit`
- focused touched-package `typecheck`
- `pnpm check`
- `pnpm build`
- `pnpm --filter @app/desktop test:e2e`
- commit hook reran `lint`, `check`, and `typecheck`

Base branch: `issue-11-export-base-matrix-workbooks` (#32).

Closes #12
