### PR TITLE
Add Member Response import

### DIFF
--- a/apps/desktop/electron/base-capability-matrix-export.test.ts
+++ b/apps/desktop/electron/base-capability-matrix-export.test.ts
@@ -16,6 +16,8 @@ const opportunityService = (): OpportunityService => ({
     suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
     exportTimestamp: '2026-05-02T10:00:00.000Z',
   })),
+  previewMemberResponseImport: vi.fn(),
+  saveMemberResponseImport: vi.fn(),
   archiveOpportunity: vi.fn(),
   restoreArchivedOpportunity: vi.fn(),
   hardDeleteArchivedOpportunity: vi.fn(),

--- a/apps/desktop/electron/cmm-ipc.test.ts
+++ b/apps/desktop/electron/cmm-ipc.test.ts
@@ -42,6 +42,35 @@ const baseCapabilityMatrix = {
   ],
 };
 
+const memberResponseImportPreview = {
+  opportunityId: opportunity.id,
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  suggestedMemberName: 'Polar Systems LLC',
+  rows: [
+    {
+      requirementId: 'requirement-1',
+      requirementNumber: '1',
+      requirementText: 'Provide secure hosting',
+      requirementRetiredAt: null,
+      capabilityScore: 3 as const,
+      pastPerformanceReference: 'Hosted IL5 workloads',
+      responseComment: 'Available immediately',
+    },
+  ],
+};
+
+const memberResponse = {
+  id: 'member-response-1',
+  opportunityId: opportunity.id,
+  memberName: 'Polar Systems LLC',
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  importedAt: '2026-05-02T11:00:00.000Z',
+  archivedAt: null,
+  evaluationState: 'candidate' as const,
+};
+
 describe('registerCmmIpcHandlers', () => {
   it('registers validated Opportunity handlers without exposing raw IPC to the renderer', async () => {
     const ipcMain = new FakeIpcMain();
@@ -74,6 +103,8 @@ describe('registerCmmIpcHandlers', () => {
         suggestedFilename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
         exportTimestamp: '2026-05-02T10:00:00.000Z',
       })),
+      previewMemberResponseImport: vi.fn(async () => memberResponseImportPreview),
+      saveMemberResponseImport: vi.fn(async () => memberResponse),
       archiveOpportunity: vi.fn(async () => ({
         ...opportunity,
         archivedAt: '2026-05-01T09:10:00.000Z',
@@ -87,8 +118,18 @@ describe('registerCmmIpcHandlers', () => {
         filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
       })),
     };
+    const memberResponseImportFileService = {
+      selectMemberResponseWorkbookForImport: vi.fn(async () => ({
+        status: 'readyForReview' as const,
+        preview: memberResponseImportPreview,
+      })),
+    };
 
-    registerCmmIpcHandlers(ipcMain, { opportunityService, baseCapabilityMatrixExportFileService });
+    registerCmmIpcHandlers(ipcMain, {
+      opportunityService,
+      baseCapabilityMatrixExportFileService,
+      memberResponseImportFileService,
+    });
 
     expect(Array.from(ipcMain.handlers.keys()).sort()).toEqual(
       [
@@ -99,6 +140,8 @@ describe('registerCmmIpcHandlers', () => {
         cmmIpcContracts.openArchivedOpportunity.channel,
         cmmIpcContracts.saveBaseCapabilityMatrix.channel,
         cmmIpcContracts.exportBaseCapabilityMatrix.channel,
+        cmmIpcContracts.selectMemberResponseWorkbookForImport.channel,
+        cmmIpcContracts.saveMemberResponseImport.channel,
         cmmIpcContracts.archiveOpportunity.channel,
         cmmIpcContracts.restoreArchivedOpportunity.channel,
         cmmIpcContracts.hardDeleteArchivedOpportunity.channel,
@@ -160,6 +203,50 @@ describe('registerCmmIpcHandlers', () => {
       opportunityId: 'opportunity-1',
       includeBlankRequirements: true,
       includeRetiredRequirements: false,
+    });
+
+    const selectMemberResponseImportHandler = ipcMain.handlers.get(
+      cmmIpcContracts.selectMemberResponseWorkbookForImport.channel,
+    );
+    await expect(selectMemberResponseImportHandler?.({}, { opportunityId: '' })).rejects.toThrow(
+      'Opportunity ID is required.',
+    );
+    await expect(
+      selectMemberResponseImportHandler?.({}, { opportunityId: 'opportunity-1' }),
+    ).resolves.toEqual({
+      status: 'readyForReview',
+      preview: memberResponseImportPreview,
+    });
+    expect(
+      memberResponseImportFileService.selectMemberResponseWorkbookForImport,
+    ).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
+    });
+
+    const saveMemberResponseImportHandler = ipcMain.handlers.get(
+      cmmIpcContracts.saveMemberResponseImport.channel,
+    );
+    await expect(
+      saveMemberResponseImportHandler?.(
+        {},
+        {
+          ...memberResponseImportPreview,
+          memberName: '   ',
+        },
+      ),
+    ).rejects.toThrow('Potential Consortium Member name is required.');
+    await expect(
+      saveMemberResponseImportHandler?.(
+        {},
+        {
+          ...memberResponseImportPreview,
+          memberName: 'Polar Systems LLC',
+        },
+      ),
+    ).resolves.toEqual(memberResponse);
+    expect(opportunityService.saveMemberResponseImport).toHaveBeenCalledWith({
+      ...memberResponseImportPreview,
+      memberName: 'Polar Systems LLC',
     });
 
     const hardDeleteHandler = ipcMain.handlers.get(

--- a/apps/desktop/electron/cmm-ipc.ts
+++ b/apps/desktop/electron/cmm-ipc.ts
@@ -4,6 +4,8 @@ import {
   type ExportBaseCapabilityMatrixIpcInput,
   type ExportBaseCapabilityMatrixIpcOutput,
   type IpcContract,
+  type SelectMemberResponseWorkbookForImportIpcInput,
+  type SelectMemberResponseWorkbookForImportIpcOutput,
   validateIpcInput,
   validateIpcOutput,
 } from '@cmm/contracts';
@@ -21,6 +23,11 @@ export type CmmIpcServices = {
       input: ExportBaseCapabilityMatrixIpcInput,
     ): Promise<ExportBaseCapabilityMatrixIpcOutput>;
   };
+  memberResponseImportFileService: {
+    selectMemberResponseWorkbookForImport(
+      input: SelectMemberResponseWorkbookForImportIpcInput,
+    ): Promise<SelectMemberResponseWorkbookForImportIpcOutput>;
+  };
 };
 
 const registerValidatedHandler = <Input, Output>(
@@ -37,7 +44,11 @@ const registerValidatedHandler = <Input, Output>(
 
 export const registerCmmIpcHandlers = (
   ipcMain: IpcMainLike,
-  { opportunityService, baseCapabilityMatrixExportFileService }: CmmIpcServices,
+  {
+    opportunityService,
+    baseCapabilityMatrixExportFileService,
+    memberResponseImportFileService,
+  }: CmmIpcServices,
 ): void => {
   registerValidatedHandler(ipcMain, cmmIpcContracts.createOpportunity, (input) =>
     opportunityService.createOpportunity(input),
@@ -59,6 +70,14 @@ export const registerCmmIpcHandlers = (
   );
   registerValidatedHandler(ipcMain, cmmIpcContracts.exportBaseCapabilityMatrix, (input) =>
     baseCapabilityMatrixExportFileService.exportBaseCapabilityMatrix(input),
+  );
+  registerValidatedHandler(
+    ipcMain,
+    cmmIpcContracts.selectMemberResponseWorkbookForImport,
+    (input) => memberResponseImportFileService.selectMemberResponseWorkbookForImport(input),
+  );
+  registerValidatedHandler(ipcMain, cmmIpcContracts.saveMemberResponseImport, (input) =>
+    opportunityService.saveMemberResponseImport(input),
   );
   registerValidatedHandler(ipcMain, cmmIpcContracts.archiveOpportunity, (input) =>
     opportunityService.archiveOpportunity(input),

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createOpportunityService } from '@cmm/application';
 import { cmmWindowLifecycleChannels, validateWindowCloseResponse } from '@cmm/contracts';
@@ -9,10 +9,11 @@ import {
   createCmmSqliteDatabase,
   createSqliteOpportunityRepository,
 } from '@cmm/persistence-sqlite';
-import { buildBaseCapabilityMatrixWorkbook } from '@cmm/workbook';
+import { buildBaseCapabilityMatrixWorkbook, parseMemberResponseWorkbook } from '@cmm/workbook';
 import { app, BrowserWindow, dialog, type IpcMainEvent, ipcMain } from 'electron';
 import { createBaseCapabilityMatrixExportFileService } from './base-capability-matrix-export';
 import { registerCmmIpcHandlers } from './cmm-ipc';
+import { createMemberResponseImportFileService } from './member-response-import';
 
 const rendererRoot = path.resolve(__dirname, '../dist');
 const preloadPath = path.resolve(__dirname, 'preload.js');
@@ -139,8 +140,18 @@ const registerHandlers = () => {
     showSaveDialog: (options) => dialog.showSaveDialog(options),
     writeFile,
   });
+  const memberResponseImportFileService = createMemberResponseImportFileService({
+    opportunityService,
+    showOpenDialog: (options) => dialog.showOpenDialog(options),
+    readFile,
+    parseMemberResponseWorkbook,
+  });
 
-  registerCmmIpcHandlers(ipcMain, { opportunityService, baseCapabilityMatrixExportFileService });
+  registerCmmIpcHandlers(ipcMain, {
+    opportunityService,
+    baseCapabilityMatrixExportFileService,
+    memberResponseImportFileService,
+  });
 };
 
 app.whenReady().then(async () => {

--- a/apps/desktop/electron/member-response-import.test.ts
+++ b/apps/desktop/electron/member-response-import.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+
+import { ApplicationError, type OpportunityService } from '@cmm/application';
+import { describe, expect, it, vi } from 'vitest';
+import { createMemberResponseImportFileService } from './member-response-import';
+
+const parsedWorkbook = {
+  metadata: {
+    workbookFormatVersion: '1',
+    opportunityId: 'opportunity-1',
+    exportTimestamp: '2026-05-02T10:00:00.000Z',
+  },
+  workbookTitle: 'Arctic Radar Upgrade',
+  memberName: 'Polar Systems LLC',
+  rows: [
+    {
+      requirementId: 'requirement-1',
+      requirementNumber: '1',
+      requirementText: 'Provide secure hosting',
+      capabilityScore: 3 as const,
+      pastPerformanceReference: 'Hosted IL5 workloads',
+      responseComment: 'Available immediately',
+    },
+  ],
+};
+
+const importPreview = {
+  opportunityId: 'opportunity-1',
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  suggestedMemberName: 'Polar Systems LLC',
+  rows: [
+    {
+      requirementId: 'requirement-1',
+      requirementNumber: '1',
+      requirementText: 'Provide secure hosting',
+      requirementRetiredAt: null,
+      capabilityScore: 3 as const,
+      pastPerformanceReference: 'Hosted IL5 workloads',
+      responseComment: 'Available immediately',
+    },
+  ],
+};
+
+const opportunityService = (): OpportunityService => ({
+  createOpportunity: vi.fn(),
+  listActiveOpportunities: vi.fn(),
+  listArchivedOpportunities: vi.fn(),
+  openOpportunity: vi.fn(),
+  openArchivedOpportunity: vi.fn(),
+  saveBaseCapabilityMatrix: vi.fn(),
+  exportBaseCapabilityMatrix: vi.fn(),
+  previewMemberResponseImport: vi.fn(async () => importPreview),
+  saveMemberResponseImport: vi.fn(),
+  archiveOpportunity: vi.fn(),
+  restoreArchivedOpportunity: vi.fn(),
+  hardDeleteArchivedOpportunity: vi.fn(),
+});
+
+describe('Member Response import file service', () => {
+  it('selects a workbook through main-owned file IO and parses workbook bytes', async () => {
+    const service = opportunityService();
+    const readFile = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const parseMemberResponseWorkbook = vi.fn(async () => parsedWorkbook);
+    const importFileService = createMemberResponseImportFileService({
+      opportunityService: service,
+      showOpenDialog: vi.fn(async () => ({
+        canceled: false,
+        filePaths: ['/tmp/Polar Systems response.xlsx'],
+      })),
+      readFile,
+      parseMemberResponseWorkbook,
+    });
+
+    await expect(
+      importFileService.selectMemberResponseWorkbookForImport({
+        opportunityId: 'opportunity-1',
+      }),
+    ).resolves.toEqual({
+      status: 'readyForReview',
+      preview: importPreview,
+    });
+    expect(readFile).toHaveBeenCalledWith('/tmp/Polar Systems response.xlsx');
+    expect(parseMemberResponseWorkbook).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+    expect(service.previewMemberResponseImport).toHaveBeenCalledWith({
+      opportunityId: 'opportunity-1',
+      sourceFilename: 'Polar Systems response.xlsx',
+      parsedWorkbook,
+    });
+  });
+
+  it('does not read a workbook when the import dialog is canceled', async () => {
+    const readFile = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const importFileService = createMemberResponseImportFileService({
+      opportunityService: opportunityService(),
+      showOpenDialog: vi.fn(async () => ({
+        canceled: true,
+        filePaths: [],
+      })),
+      readFile,
+      parseMemberResponseWorkbook: vi.fn(async () => parsedWorkbook),
+    });
+
+    await expect(
+      importFileService.selectMemberResponseWorkbookForImport({
+        opportunityId: 'opportunity-1',
+      }),
+    ).resolves.toEqual({
+      status: 'canceled',
+      preview: null,
+    });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('returns a typed rejection when the workbook has no usable Member Response rows', async () => {
+    const service = opportunityService();
+    vi.mocked(service.previewMemberResponseImport).mockRejectedValue(
+      new ApplicationError(
+        'memberResponse.noUsableRows',
+        'Member Response workbook has no usable response rows.',
+      ),
+    );
+    const importFileService = createMemberResponseImportFileService({
+      opportunityService: service,
+      showOpenDialog: vi.fn(async () => ({
+        canceled: false,
+        filePaths: ['/tmp/empty response.xlsx'],
+      })),
+      readFile: vi.fn(async () => new Uint8Array([1, 2, 3])),
+      parseMemberResponseWorkbook: vi.fn(async () => parsedWorkbook),
+    });
+
+    await expect(
+      importFileService.selectMemberResponseWorkbookForImport({
+        opportunityId: 'opportunity-1',
+      }),
+    ).resolves.toEqual({
+      status: 'rejected',
+      error: { code: 'memberResponse.noUsableRows' },
+      preview: null,
+    });
+  });
+});

--- a/apps/desktop/electron/member-response-import.ts
+++ b/apps/desktop/electron/member-response-import.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import {
+  ApplicationError,
+  type OpportunityService,
+  type ParsedMemberResponseWorkbook,
+} from '@cmm/application';
+import type {
+  SelectMemberResponseWorkbookForImportIpcInput,
+  SelectMemberResponseWorkbookForImportIpcOutput,
+} from '@cmm/contracts';
+
+export type OpenDialogResult = {
+  canceled: boolean;
+  filePaths: string[];
+};
+
+export type OpenDialog = (options: {
+  title: string;
+  properties: ['openFile'];
+  filters: { name: string; extensions: string[] }[];
+}) => Promise<OpenDialogResult>;
+
+export type ReadFile = (filePath: string) => Promise<Uint8Array>;
+
+export type ParseMemberResponseWorkbook = (
+  buffer: Uint8Array,
+) => Promise<ParsedMemberResponseWorkbook>;
+
+export type MemberResponseImportFileService = {
+  selectMemberResponseWorkbookForImport(
+    input: SelectMemberResponseWorkbookForImportIpcInput,
+  ): Promise<SelectMemberResponseWorkbookForImportIpcOutput>;
+};
+
+export type CreateMemberResponseImportFileServiceOptions = {
+  opportunityService: OpportunityService;
+  showOpenDialog: OpenDialog;
+  readFile: ReadFile;
+  parseMemberResponseWorkbook: ParseMemberResponseWorkbook;
+};
+
+export const createMemberResponseImportFileService = ({
+  opportunityService,
+  showOpenDialog,
+  readFile,
+  parseMemberResponseWorkbook,
+}: CreateMemberResponseImportFileServiceOptions): MemberResponseImportFileService => ({
+  async selectMemberResponseWorkbookForImport(input) {
+    const openDialogResult = await showOpenDialog({
+      title: 'Import Member Response',
+      properties: ['openFile'],
+      filters: [{ name: 'Excel Workbook', extensions: ['xlsx'] }],
+    });
+
+    const filePath = openDialogResult.filePaths[0];
+    if (openDialogResult.canceled || !filePath) {
+      return {
+        status: 'canceled',
+        preview: null,
+      };
+    }
+
+    const workbook = await readFile(filePath);
+    const parsedWorkbook = await parseMemberResponseWorkbook(workbook);
+    try {
+      const preview = await opportunityService.previewMemberResponseImport({
+        opportunityId: input.opportunityId,
+        sourceFilename: path.basename(filePath),
+        parsedWorkbook,
+      });
+
+      return {
+        status: 'readyForReview',
+        preview,
+      };
+    } catch (error) {
+      if (error instanceof ApplicationError && error.code === 'memberResponse.noUsableRows') {
+        return {
+          status: 'rejected',
+          error: { code: error.code },
+          preview: null,
+        };
+      }
+
+      throw error;
+    }
+  },
+});

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -6,6 +6,8 @@ import {
   type OpenOpportunityIpcInput,
   type OpportunityLifecycleIpcInput,
   type SaveBaseCapabilityMatrixIpcInput,
+  type SaveMemberResponseImportIpcInput,
+  type SelectMemberResponseWorkbookForImportIpcInput,
   validateWindowCloseRequest,
   type WindowCloseResponseDto,
 } from '@cmm/contracts';
@@ -26,6 +28,10 @@ contextBridge.exposeInMainWorld('cmmApi', {
     ipcRenderer.invoke(cmmIpcContracts.saveBaseCapabilityMatrix.channel, input),
   exportBaseCapabilityMatrix: (input: ExportBaseCapabilityMatrixIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.exportBaseCapabilityMatrix.channel, input),
+  selectMemberResponseWorkbookForImport: (input: SelectMemberResponseWorkbookForImportIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.selectMemberResponseWorkbookForImport.channel, input),
+  saveMemberResponseImport: (input: SaveMemberResponseImportIpcInput) =>
+    ipcRenderer.invoke(cmmIpcContracts.saveMemberResponseImport.channel, input),
   archiveOpportunity: (input: OpportunityLifecycleIpcInput) =>
     ipcRenderer.invoke(cmmIpcContracts.archiveOpportunity.channel, input),
   restoreArchivedOpportunity: (input: OpportunityLifecycleIpcInput) =>

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -37,6 +37,24 @@ const emptyBaseCapabilityMatrix = (opportunityId: string): BaseCapabilityMatrixD
   requirements: [],
 });
 
+const memberResponseImportPreview = {
+  opportunityId: activeOpportunity.id,
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  suggestedMemberName: 'Polar Systems LLC',
+  rows: [
+    {
+      requirementId: 'requirement-1',
+      requirementNumber: '1',
+      requirementText: 'Provide secure hosting',
+      requirementRetiredAt: null,
+      capabilityScore: 3 as const,
+      pastPerformanceReference: 'Hosted IL5 workloads',
+      responseComment: 'Available immediately',
+    },
+  ],
+};
+
 const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
   const api: Window['cmmApi'] = {
     createOpportunity: vi.fn(),
@@ -63,6 +81,20 @@ const installCmmApi = (overrides: Partial<Window['cmmApi']> = {}) => {
     exportBaseCapabilityMatrix: vi.fn(async () => ({
       status: 'exported' as const,
       filename: 'Arctic Radar Upgrade - Base Capability Matrix.xlsx',
+    })),
+    selectMemberResponseWorkbookForImport: vi.fn(async () => ({
+      status: 'readyForReview' as const,
+      preview: memberResponseImportPreview,
+    })),
+    saveMemberResponseImport: vi.fn(async (input) => ({
+      id: 'member-response-1',
+      opportunityId: input.opportunityId,
+      memberName: input.memberName.trim(),
+      sourceFilename: input.sourceFilename,
+      workbookTitle: input.workbookTitle,
+      importedAt: '2026-05-02T11:00:00.000Z',
+      archivedAt: null,
+      evaluationState: 'candidate' as const,
     })),
     archiveOpportunity: vi.fn(),
     restoreArchivedOpportunity: vi.fn(),
@@ -889,6 +921,72 @@ describe('App', () => {
       includeBlankRequirements: true,
       includeRetiredRequirements: true,
     });
+  });
+
+  it('imports a Member Response after Potential Consortium Member name confirmation', async () => {
+    const api = installCmmApi({
+      openOpportunity: vi.fn(async () => ({
+        opportunity: activeOpportunity,
+        baseCapabilityMatrix: {
+          opportunityId: activeOpportunity.id,
+          revision: 1,
+          requirements: [
+            {
+              id: 'requirement-1',
+              text: 'Provide secure hosting',
+              level: 1,
+              position: 0,
+              retiredAt: null,
+            },
+          ],
+        },
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByRole('button', { name: 'Import Member Response' }));
+
+    expect(api.selectMemberResponseWorkbookForImport).toHaveBeenCalledWith({
+      opportunityId: activeOpportunity.id,
+    });
+    expect(await screen.findByDisplayValue('Polar Systems LLC')).toBeVisible();
+
+    await user.clear(screen.getByLabelText('Potential Consortium Member'));
+    await user.type(screen.getByLabelText('Potential Consortium Member'), 'Polar Systems Intl');
+    await user.click(screen.getByRole('button', { name: 'Save Member Response' }));
+
+    expect(api.saveMemberResponseImport).toHaveBeenCalledWith({
+      ...memberResponseImportPreview,
+      memberName: 'Polar Systems Intl',
+    });
+    expect(
+      await screen.findByText('Imported Member Response for Polar Systems Intl.'),
+    ).toBeVisible();
+  });
+
+  it('shows recovery when an imported workbook has no usable Member Response rows', async () => {
+    installCmmApi({
+      selectMemberResponseWorkbookForImport: vi.fn(async () => ({
+        status: 'rejected' as const,
+        error: { code: 'memberResponse.noUsableRows' as const },
+        preview: null,
+      })),
+    });
+    const user = userEvent.setup();
+
+    render(<App />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open Arctic Radar Upgrade' }));
+    await user.click(screen.getByRole('button', { name: 'Import Member Response' }));
+
+    expect(
+      await screen.findByText(
+        'No usable response rows found. Ask the potential consortium member to fill in at least one response field, then import the returned workbook again.',
+      ),
+    ).toBeVisible();
   });
 
   it('inserts a new active Requirement from Enter and focuses the new text field', async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import type {
   BaseCapabilityMatrixDto,
   CreateOpportunityIpcInput,
+  MemberResponseImportPreviewDto,
   OpenOpportunityIpcOutput,
   OpportunityDto,
   RequirementDto,
@@ -34,6 +35,11 @@ type BaseCapabilityMatrixExportChoices = {
 type ExportPreflightState = BaseCapabilityMatrixExportChoices & {
   blankRequirementCount: number;
   retiredRequirementCount: number;
+};
+type MemberResponseImportReviewState = {
+  preview: MemberResponseImportPreviewDto;
+  memberName: string;
+  saveState: 'idle' | 'saving';
 };
 
 type NumberedRequirement = {
@@ -165,6 +171,8 @@ function App(): React.JSX.Element {
   const [showRetiredRequirements, setShowRetiredRequirements] = useState(false);
   const [matrixSaveState, setMatrixSaveState] = useState<MatrixSaveState>('idle');
   const [exportPreflight, setExportPreflight] = useState<ExportPreflightState | null>(null);
+  const [memberResponseImportReview, setMemberResponseImportReview] =
+    useState<MemberResponseImportReviewState | null>(null);
   const [pendingRequirementFocusId, setPendingRequirementFocusId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<OpportunityFormState>(emptyForm);
@@ -359,6 +367,7 @@ function App(): React.JSX.Element {
     });
     setShowRetiredRequirements(false);
     setExportPreflight(null);
+    setMemberResponseImportReview(null);
     draftVersionRef.current = 0;
     setTrackedMatrixSaveState('idle');
     await refreshOpportunities();
@@ -373,6 +382,7 @@ function App(): React.JSX.Element {
 
     draftVersionRef.current += 1;
     setExportPreflight(null);
+    setMemberResponseImportReview(null);
     setOpenedOpportunity((current) => {
       if (!current || current.lifecycle === 'archived') {
         return current;
@@ -779,6 +789,98 @@ function App(): React.JSX.Element {
     }
   };
 
+  const importMemberResponseWorkbook = async () => {
+    if (!openedOpportunity || openedOpportunity.lifecycle !== 'active') {
+      return;
+    }
+
+    setError(null);
+    setNotice(null);
+    setExportPreflight(null);
+    setMemberResponseImportReview(null);
+    try {
+      if (!(await flushBaseCapabilityMatrixBeforeProceeding())) {
+        return;
+      }
+
+      const current = openedOpportunityRef.current;
+      if (!current || current.lifecycle !== 'active') {
+        return;
+      }
+
+      const result = await window.cmmApi.selectMemberResponseWorkbookForImport({
+        opportunityId: current.opportunity.id,
+      });
+
+      if (result.status === 'canceled') {
+        setNotice('Import canceled.');
+        return;
+      }
+
+      if (result.status === 'rejected') {
+        setError(
+          'No usable response rows found. Ask the potential consortium member to fill in at least one response field, then import the returned workbook again.',
+        );
+        return;
+      }
+
+      setMemberResponseImportReview({
+        preview: result.preview,
+        memberName: result.preview.suggestedMemberName,
+        saveState: 'idle',
+      });
+    } catch (unknownError) {
+      setError(getErrorMessage(unknownError, 'Unable to import Member Response.'));
+    }
+  };
+
+  const updateMemberResponseImportName = (memberName: string) => {
+    setMemberResponseImportReview((current) =>
+      current
+        ? {
+            ...current,
+            memberName,
+          }
+        : current,
+    );
+  };
+
+  const saveMemberResponseImport = async () => {
+    if (!memberResponseImportReview) {
+      return;
+    }
+
+    setError(null);
+    setNotice(null);
+    setMemberResponseImportReview((current) =>
+      current
+        ? {
+            ...current,
+            saveState: 'saving',
+          }
+        : current,
+    );
+
+    try {
+      const saved = await window.cmmApi.saveMemberResponseImport({
+        ...memberResponseImportReview.preview,
+        memberName: memberResponseImportReview.memberName,
+      });
+      setMemberResponseImportReview(null);
+      setNotice(`Imported Member Response for ${saved.memberName}.`);
+    } catch (unknownError) {
+      setError(getErrorMessage(unknownError, 'Unable to save Member Response.'));
+      setMemberResponseImportReview((current) =>
+        current
+          ? {
+              ...current,
+              saveState: 'idle',
+            }
+          : current,
+      );
+    }
+  };
+
   const restoreOpenedOpportunity = async () => {
     if (!openedOpportunity || openedOpportunity.lifecycle !== 'archived') {
       return;
@@ -1018,6 +1120,13 @@ function App(): React.JSX.Element {
                   <Button
                     disabled={matrixSaveState === 'saving'}
                     variant="secondary"
+                    onClick={() => void importMemberResponseWorkbook()}
+                  >
+                    Import Member Response
+                  </Button>
+                  <Button
+                    disabled={matrixSaveState === 'saving'}
+                    variant="secondary"
                     onClick={() => void saveMatrix()}
                   >
                     Save Matrix
@@ -1113,6 +1222,37 @@ function App(): React.JSX.Element {
                     </section>
                   ) : null}
                 </div>
+              ) : null}
+
+              {memberResponseImportReview ? (
+                <section
+                  aria-label="Member Response import review"
+                  className="member-response-import-review"
+                >
+                  <Field htmlFor="member-response-member-name" label="Potential Consortium Member">
+                    <TextInput
+                      autoFocus
+                      id="member-response-member-name"
+                      value={memberResponseImportReview.memberName}
+                      onChange={(event) => updateMemberResponseImportName(event.target.value)}
+                    />
+                  </Field>
+                  <div className="import-review-actions">
+                    <Button
+                      disabled={
+                        memberResponseImportReview.saveState === 'saving' ||
+                        memberResponseImportReview.memberName.trim().length === 0
+                      }
+                      variant="primary"
+                      onClick={() => void saveMemberResponseImport()}
+                    >
+                      Save Member Response
+                    </Button>
+                    <Button variant="ghost" onClick={() => setMemberResponseImportReview(null)}>
+                      Cancel Import
+                    </Button>
+                  </div>
+                </section>
               ) : null}
 
               {numberedRequirements.length === 0 ? (

--- a/apps/desktop/src/electron-api.d.ts
+++ b/apps/desktop/src/electron-api.d.ts
@@ -4,11 +4,15 @@ import type {
   HardDeleteArchivedOpportunityIpcOutput,
   ExportBaseCapabilityMatrixIpcInput,
   ExportBaseCapabilityMatrixIpcOutput,
+  MemberResponseDto,
   OpenOpportunityIpcInput,
   OpenOpportunityIpcOutput,
   OpportunityLifecycleIpcInput,
   OpportunityDto,
   SaveBaseCapabilityMatrixIpcInput,
+  SaveMemberResponseImportIpcInput,
+  SelectMemberResponseWorkbookForImportIpcInput,
+  SelectMemberResponseWorkbookForImportIpcOutput,
 } from '@cmm/contracts';
 
 export interface CmmApi {
@@ -23,6 +27,10 @@ export interface CmmApi {
   exportBaseCapabilityMatrix(
     input: ExportBaseCapabilityMatrixIpcInput,
   ): Promise<ExportBaseCapabilityMatrixIpcOutput>;
+  selectMemberResponseWorkbookForImport(
+    input: SelectMemberResponseWorkbookForImportIpcInput,
+  ): Promise<SelectMemberResponseWorkbookForImportIpcOutput>;
+  saveMemberResponseImport(input: SaveMemberResponseImportIpcInput): Promise<MemberResponseDto>;
   archiveOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   restoreArchivedOpportunity(input: OpportunityLifecycleIpcInput): Promise<OpportunityDto>;
   hardDeleteArchivedOpportunity(

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -345,6 +345,21 @@ textarea {
   gap: 8px;
 }
 
+.member-response-import-review {
+  display: grid;
+  gap: 12px;
+  border: 1px solid #c8d2c5;
+  background: #f7faf4;
+  color: #1c2228;
+  padding: 14px;
+}
+
+.import-review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 .matrix-outline {
   display: grid;
   gap: 8px;

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -1,10 +1,14 @@
 import type {
   BaseCapabilityMatrix,
+  CapabilityScore,
   CreateOpportunityInput,
   IsoDateTime,
+  MemberResponse,
+  MemberResponseRow,
   Opportunity,
   OpportunityId,
   Requirement,
+  RequirementId,
 } from '@cmm/domain';
 import {
   normalizeOptionalText,
@@ -38,6 +42,9 @@ export type OpportunityRepository = {
   hardDeleteArchivedOpportunity(opportunityId: OpportunityId): Promise<void>;
   loadBaseCapabilityMatrix(opportunityId: OpportunityId): Promise<BaseCapabilityMatrix>;
   saveBaseCapabilityMatrix(matrix: BaseCapabilityMatrix): Promise<BaseCapabilityMatrix>;
+  listActiveMemberResponses(opportunityId: OpportunityId): Promise<MemberResponse[]>;
+  loadMemberResponseRows(memberResponseId: string): Promise<MemberResponseRow[]>;
+  saveActiveMemberResponse(input: SaveActiveMemberResponseRepositoryInput): Promise<MemberResponse>;
 };
 
 export type OpenOpportunityInput = {
@@ -70,6 +77,61 @@ export type BaseCapabilityMatrixExportChoices = {
 export type ExportBaseCapabilityMatrixInput = {
   opportunityId: OpportunityId;
 } & BaseCapabilityMatrixExportChoices;
+
+export type ParsedMemberResponseWorkbookRow = {
+  requirementId: string;
+  requirementNumber: string;
+  requirementText: string;
+  capabilityScore: CapabilityScore | null;
+  pastPerformanceReference: string;
+  responseComment: string;
+};
+
+export type ParsedMemberResponseWorkbook = {
+  metadata: {
+    workbookFormatVersion: string;
+    opportunityId: string;
+    exportTimestamp: IsoDateTime;
+  };
+  workbookTitle: string;
+  memberName: string;
+  rows: ParsedMemberResponseWorkbookRow[];
+};
+
+export type PreviewMemberResponseImportInput = {
+  opportunityId: OpportunityId;
+  sourceFilename: string | null;
+  parsedWorkbook: ParsedMemberResponseWorkbook;
+};
+
+export type MemberResponseImportPreviewRow = {
+  requirementId: RequirementId;
+  requirementNumber: string;
+  requirementText: string;
+  requirementRetiredAt: IsoDateTime | null;
+  capabilityScore: CapabilityScore | null;
+  pastPerformanceReference: string;
+  responseComment: string;
+};
+
+export type MemberResponseImportPreview = {
+  opportunityId: OpportunityId;
+  sourceFilename: string | null;
+  workbookTitle: string | null;
+  suggestedMemberName: string;
+  rows: MemberResponseImportPreviewRow[];
+};
+
+export type SaveMemberResponseImportInput = MemberResponseImportPreview & {
+  memberName: string;
+};
+
+export type SaveActiveMemberResponseRepositoryInput = {
+  memberResponse: MemberResponse;
+  rows: MemberResponseRow[];
+  normalizedMemberName: string;
+  archivedAt: IsoDateTime;
+};
 
 export type OpenOpportunityResult = {
   opportunity: Opportunity;
@@ -105,6 +167,10 @@ export type OpportunityService = {
   exportBaseCapabilityMatrix(
     input: ExportBaseCapabilityMatrixInput,
   ): Promise<ExportBaseCapabilityMatrixResult>;
+  previewMemberResponseImport(
+    input: PreviewMemberResponseImportInput,
+  ): Promise<MemberResponseImportPreview>;
+  saveMemberResponseImport(input: SaveMemberResponseImportInput): Promise<MemberResponse>;
   archiveOpportunity(input: ArchiveOpportunityInput): Promise<Opportunity>;
   restoreArchivedOpportunity(input: RestoreArchivedOpportunityInput): Promise<Opportunity>;
   hardDeleteArchivedOpportunity(input: HardDeleteArchivedOpportunityInput): Promise<void>;
@@ -122,7 +188,9 @@ export class ApplicationError extends Error {
     readonly code:
       | 'opportunity.nameRequired'
       | 'opportunity.notFound'
-      | 'baseMatrix.revisionConflict',
+      | 'baseMatrix.revisionConflict'
+      | 'memberResponse.noUsableRows'
+      | 'memberResponse.memberNameRequired',
     message: string,
   ) {
     super(message);
@@ -237,6 +305,125 @@ export const createOpportunityService = ({
     };
   },
 
+  async previewMemberResponseImport(input) {
+    const opportunity = await repository.findActiveOpportunityById(input.opportunityId);
+    if (!opportunity) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    const baseCapabilityMatrix = await repository.loadBaseCapabilityMatrix(input.opportunityId);
+    const requirementsById = new Map(
+      baseCapabilityMatrix.requirements.map((requirement) => [requirement.id, requirement]),
+    );
+    const rows = input.parsedWorkbook.rows.flatMap((parsedRow) => {
+      const requirementId = normalizeRequiredText(parsedRow.requirementId);
+      const requirement = requirementsById.get(requirementId);
+      if (!requirement || !isUsableParsedMemberResponseRow(parsedRow)) {
+        return [];
+      }
+
+      return [
+        {
+          requirementId: requirement.id,
+          requirementNumber: normalizeRequiredText(parsedRow.requirementNumber),
+          requirementText: normalizeRequiredText(parsedRow.requirementText) || requirement.text,
+          requirementRetiredAt: requirement.retiredAt,
+          capabilityScore: parsedRow.capabilityScore,
+          pastPerformanceReference: normalizeResponseText(parsedRow.pastPerformanceReference),
+          responseComment: normalizeResponseText(parsedRow.responseComment),
+        },
+      ];
+    });
+
+    if (rows.length === 0) {
+      throw new ApplicationError(
+        'memberResponse.noUsableRows',
+        'Member Response workbook has no usable response rows.',
+      );
+    }
+
+    return {
+      opportunityId: input.opportunityId,
+      sourceFilename: normalizeOptionalText(input.sourceFilename),
+      workbookTitle: normalizeOptionalText(input.parsedWorkbook.workbookTitle),
+      suggestedMemberName: getSuggestedMemberName(
+        input.parsedWorkbook.memberName,
+        input.sourceFilename,
+      ),
+      rows,
+    };
+  },
+
+  async saveMemberResponseImport(input) {
+    const opportunity = await repository.findActiveOpportunityById(input.opportunityId);
+    if (!opportunity) {
+      throw new ApplicationError('opportunity.notFound', 'Opportunity not found.');
+    }
+
+    const memberName = normalizeMemberName(input.memberName);
+    if (!memberName) {
+      throw new ApplicationError(
+        'memberResponse.memberNameRequired',
+        'Potential Consortium Member name is required.',
+      );
+    }
+
+    const baseCapabilityMatrix = await repository.loadBaseCapabilityMatrix(input.opportunityId);
+    const requirementsById = new Map(
+      baseCapabilityMatrix.requirements.map((requirement) => [requirement.id, requirement]),
+    );
+    const usableRows = input.rows.flatMap((row) => {
+      const requirement = requirementsById.get(row.requirementId);
+      if (!requirement || !isUsableMemberResponseImportRow(row)) {
+        return [];
+      }
+
+      return [
+        {
+          requirementId: requirement.id,
+          requirementNumber: normalizeRequiredText(row.requirementNumber),
+          requirementText: normalizeRequiredText(row.requirementText) || requirement.text,
+          capabilityScore: row.capabilityScore,
+          pastPerformanceReference: normalizeResponseText(row.pastPerformanceReference),
+          responseComment: normalizeResponseText(row.responseComment),
+        },
+      ];
+    });
+
+    if (usableRows.length === 0) {
+      throw new ApplicationError(
+        'memberResponse.noUsableRows',
+        'Member Response workbook has no usable response rows.',
+      );
+    }
+
+    const importedAt = clock.now();
+    const memberResponseId = ids.next();
+    const memberResponse: MemberResponse = {
+      id: memberResponseId,
+      opportunityId: input.opportunityId,
+      memberName,
+      sourceFilename: normalizeOptionalText(input.sourceFilename),
+      workbookTitle: normalizeOptionalText(input.workbookTitle),
+      importedAt,
+      archivedAt: null,
+      evaluationState: 'candidate',
+    };
+    const rows: MemberResponseRow[] = usableRows.map((row, position) => ({
+      id: ids.next(),
+      memberResponseId,
+      ...row,
+      position,
+    }));
+
+    return repository.saveActiveMemberResponse({
+      memberResponse,
+      rows,
+      normalizedMemberName: normalizeMemberIdentity(memberName),
+      archivedAt: importedAt,
+    });
+  },
+
   async archiveOpportunity(input) {
     const existing = await repository.findActiveOpportunityById(input.opportunityId);
     if (!existing) {
@@ -273,4 +460,40 @@ const sanitizeFilenameCharacter = (character: string): string =>
 const toWorkbookFilenameStem = (name: string): string => {
   const stem = name.split('').map(sanitizeFilenameCharacter).join('').replace(/\s+/g, ' ').trim();
   return stem.length > 0 ? stem : 'Opportunity';
+};
+
+const normalizeResponseText = (value: string): string =>
+  value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+
+const isUsableParsedMemberResponseRow = (row: ParsedMemberResponseWorkbookRow): boolean =>
+  row.capabilityScore !== null ||
+  normalizeResponseText(row.pastPerformanceReference).length > 0 ||
+  normalizeResponseText(row.responseComment).length > 0;
+
+const isUsableMemberResponseImportRow = (row: MemberResponseImportPreviewRow): boolean =>
+  row.capabilityScore !== null ||
+  normalizeResponseText(row.pastPerformanceReference).length > 0 ||
+  normalizeResponseText(row.responseComment).length > 0;
+
+const normalizeMemberName = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+const normalizeMemberIdentity = (value: string): string => normalizeMemberName(value).toLowerCase();
+
+const getSuggestedMemberName = (
+  workbookMemberName: string,
+  sourceFilename: string | null,
+): string => {
+  const normalizedMemberName = normalizeRequiredText(workbookMemberName);
+  if (normalizedMemberName) {
+    return normalizedMemberName;
+  }
+
+  const filename = normalizeOptionalText(sourceFilename);
+  if (!filename) {
+    return '';
+  }
+
+  const extensionStart = filename.lastIndexOf('.');
+  const stem = extensionStart > 0 ? filename.slice(0, extensionStart) : filename;
+  return normalizeRequiredText(stem);
 };

--- a/packages/application/src/opportunity-service.test.ts
+++ b/packages/application/src/opportunity-service.test.ts
@@ -1,14 +1,25 @@
-import type { BaseCapabilityMatrix, IsoDateTime, Opportunity, OpportunityId } from '@cmm/domain';
+import type {
+  BaseCapabilityMatrix,
+  IsoDateTime,
+  MemberResponse,
+  MemberResponseRow,
+  Opportunity,
+  OpportunityId,
+} from '@cmm/domain';
 import { describe, expect, it } from 'vitest';
 import {
   type BuildBaseCapabilityMatrixWorkbookInput,
   createOpportunityService,
   type OpportunityRepository,
+  type SaveActiveMemberResponseRepositoryInput,
 } from './index';
 
 class InMemoryOpportunityRepository implements OpportunityRepository {
   readonly opportunities = new Map<OpportunityId, Opportunity>();
   readonly matrices = new Map<OpportunityId, BaseCapabilityMatrix>();
+  readonly memberResponses = new Map<string, MemberResponse>();
+  readonly memberResponseRows = new Map<string, MemberResponseRow[]>();
+  readonly normalizedMemberNames = new Map<string, string>();
 
   async saveOpportunity(opportunity: Opportunity): Promise<void> {
     this.opportunities.set(opportunity.id, opportunity);
@@ -122,6 +133,40 @@ class InMemoryOpportunityRepository implements OpportunityRepository {
     };
     this.matrices.set(matrix.opportunityId, saved);
     return saved;
+  }
+
+  async listActiveMemberResponses(opportunityId: OpportunityId): Promise<MemberResponse[]> {
+    return Array.from(this.memberResponses.values()).filter(
+      (memberResponse) =>
+        memberResponse.opportunityId === opportunityId && memberResponse.archivedAt === null,
+    );
+  }
+
+  async loadMemberResponseRows(memberResponseId: string): Promise<MemberResponseRow[]> {
+    return this.memberResponseRows.get(memberResponseId) ?? [];
+  }
+
+  async saveActiveMemberResponse(
+    input: SaveActiveMemberResponseRepositoryInput,
+  ): Promise<MemberResponse> {
+    for (const [memberResponseId, memberResponse] of this.memberResponses) {
+      if (
+        memberResponse.opportunityId === input.memberResponse.opportunityId &&
+        memberResponse.archivedAt === null &&
+        this.normalizedMemberNames.get(memberResponseId) === input.normalizedMemberName
+      ) {
+        this.memberResponses.set(memberResponseId, {
+          ...memberResponse,
+          archivedAt: input.archivedAt,
+          evaluationState: null,
+        });
+      }
+    }
+
+    this.memberResponses.set(input.memberResponse.id, input.memberResponse);
+    this.normalizedMemberNames.set(input.memberResponse.id, input.normalizedMemberName);
+    this.memberResponseRows.set(input.memberResponse.id, input.rows);
+    return input.memberResponse;
   }
 }
 
@@ -490,6 +535,233 @@ describe('OpportunityService', () => {
         includeBlankRequirements: true,
         includeRetiredRequirements: false,
       },
+    });
+  });
+
+  it('previews a clean Member Response import by mapping hidden Requirement IDs to active and retired Requirements', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const opportunity = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-active',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+        {
+          id: 'requirement-retired',
+          text: 'Retired draft Requirement',
+          level: 1,
+          position: 1,
+          retiredAt: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+    });
+
+    await expect(
+      service.previewMemberResponseImport({
+        opportunityId: opportunity.id,
+        sourceFilename: 'Polar Systems response.xlsx',
+        parsedWorkbook: {
+          metadata: {
+            workbookFormatVersion: '1',
+            opportunityId: opportunity.id,
+            exportTimestamp: '2026-05-02T10:00:00.000Z',
+          },
+          workbookTitle: 'Arctic Radar Upgrade',
+          memberName: 'Polar Systems LLC',
+          rows: [
+            {
+              requirementId: 'requirement-active',
+              requirementNumber: '99',
+              requirementText: 'Edited visible text',
+              capabilityScore: 3,
+              pastPerformanceReference: 'Hosted IL5 workloads',
+              responseComment: 'Available immediately',
+            },
+            {
+              requirementId: 'requirement-retired',
+              requirementNumber: '100',
+              requirementText: 'Edited retired text',
+              capabilityScore: 1,
+              pastPerformanceReference: 'Legacy support',
+              responseComment: '',
+            },
+          ],
+        },
+      }),
+    ).resolves.toEqual({
+      opportunityId: opportunity.id,
+      sourceFilename: 'Polar Systems response.xlsx',
+      workbookTitle: 'Arctic Radar Upgrade',
+      suggestedMemberName: 'Polar Systems LLC',
+      rows: [
+        {
+          requirementId: 'requirement-active',
+          requirementNumber: '99',
+          requirementText: 'Edited visible text',
+          requirementRetiredAt: null,
+          capabilityScore: 3,
+          pastPerformanceReference: 'Hosted IL5 workloads',
+          responseComment: 'Available immediately',
+        },
+        {
+          requirementId: 'requirement-retired',
+          requirementNumber: '100',
+          requirementText: 'Edited retired text',
+          requirementRetiredAt: '2026-05-01T10:00:00.000Z',
+          capabilityScore: 1,
+          pastPerformanceReference: 'Legacy support',
+          responseComment: '',
+        },
+      ],
+    });
+  });
+
+  it('saves a reviewed Member Response using the confirmed Potential Consortium Member name', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const idValues = ['opportunity-1', 'member-response-1', 'member-response-row-1'];
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-02T11:00:00.000Z']),
+      ids: {
+        next: () => {
+          const id = idValues.shift();
+          if (!id) {
+            throw new Error('No ID configured for test.');
+          }
+          return id;
+        },
+      },
+    });
+
+    const opportunity = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+    const preview = await service.previewMemberResponseImport({
+      opportunityId: opportunity.id,
+      sourceFilename: 'Polar Systems response.xlsx',
+      parsedWorkbook: {
+        metadata: {
+          workbookFormatVersion: '1',
+          opportunityId: opportunity.id,
+          exportTimestamp: '2026-05-02T10:00:00.000Z',
+        },
+        workbookTitle: 'Arctic Radar Upgrade',
+        memberName: 'Polar Systems LLC',
+        rows: [
+          {
+            requirementId: 'requirement-1',
+            requirementNumber: '1',
+            requirementText: 'Provide secure hosting',
+            capabilityScore: 3,
+            pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+            responseComment: 'Prime experience\nAvailable immediately',
+          },
+        ],
+      },
+    });
+
+    await expect(
+      service.saveMemberResponseImport({
+        ...preview,
+        memberName: ' Polar Systems International ',
+      }),
+    ).resolves.toEqual({
+      id: 'member-response-1',
+      opportunityId: opportunity.id,
+      memberName: 'Polar Systems International',
+      sourceFilename: 'Polar Systems response.xlsx',
+      workbookTitle: 'Arctic Radar Upgrade',
+      importedAt: '2026-05-02T11:00:00.000Z',
+      archivedAt: null,
+      evaluationState: 'candidate',
+    });
+    expect(repository.memberResponseRows.get('member-response-1')).toEqual([
+      {
+        id: 'member-response-row-1',
+        memberResponseId: 'member-response-1',
+        requirementId: 'requirement-1',
+        requirementNumber: '1',
+        requirementText: 'Provide secure hosting',
+        capabilityScore: 3,
+        pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+        responseComment: 'Prime experience\nAvailable immediately',
+        position: 0,
+      },
+    ]);
+  });
+
+  it('rejects Member Response workbooks with no usable response rows', async () => {
+    const repository = new InMemoryOpportunityRepository();
+    const service = createOpportunityService({
+      repository,
+      clock: createClock(['2026-05-01T09:00:00.000Z']),
+      ids: { next: () => 'opportunity-1' },
+    });
+
+    const opportunity = await service.createOpportunity({ name: 'Arctic Radar Upgrade' });
+    await service.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+
+    await expect(
+      service.previewMemberResponseImport({
+        opportunityId: opportunity.id,
+        sourceFilename: 'empty response.xlsx',
+        parsedWorkbook: {
+          metadata: {
+            workbookFormatVersion: '1',
+            opportunityId: opportunity.id,
+            exportTimestamp: '2026-05-02T10:00:00.000Z',
+          },
+          workbookTitle: 'Arctic Radar Upgrade',
+          memberName: 'Polar Systems LLC',
+          rows: [
+            {
+              requirementId: 'requirement-1',
+              requirementNumber: '1',
+              requirementText: 'Provide secure hosting',
+              capabilityScore: null,
+              pastPerformanceReference: '   ',
+              responseComment: '',
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: 'memberResponse.noUsableRows',
     });
   });
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 const isoDateTimeSchema = z.string().min(1);
 const nullableTextSchema = z.string().nullable();
+const capabilityScoreSchema = z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]);
 
 const opportunitySchema = z.object({
   id: z.string().min(1),
@@ -47,6 +48,59 @@ const baseCapabilityMatrixSchema = z.object({
   requirements: z.array(requirementSchema),
 });
 
+const memberResponseImportPreviewRowSchema = z.object({
+  requirementId: z.string().min(1),
+  requirementNumber: z.string(),
+  requirementText: z.string(),
+  requirementRetiredAt: isoDateTimeSchema.nullable(),
+  capabilityScore: capabilityScoreSchema.nullable(),
+  pastPerformanceReference: z.string(),
+  responseComment: z.string(),
+});
+
+const memberResponseImportPreviewSchema = z.object({
+  opportunityId: z.string().min(1),
+  sourceFilename: nullableTextSchema,
+  workbookTitle: nullableTextSchema,
+  suggestedMemberName: z.string(),
+  rows: z.array(memberResponseImportPreviewRowSchema).min(1),
+});
+
+const selectMemberResponseWorkbookForImportOutputSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('readyForReview'),
+    preview: memberResponseImportPreviewSchema,
+  }),
+  z.object({
+    status: z.literal('canceled'),
+    preview: z.null(),
+  }),
+  z.object({
+    status: z.literal('rejected'),
+    error: z.object({
+      code: z.literal('memberResponse.noUsableRows'),
+    }),
+    preview: z.null(),
+  }),
+]);
+
+const saveMemberResponseImportInputSchema = memberResponseImportPreviewSchema.extend({
+  memberName: z
+    .string()
+    .refine((value) => value.trim().length > 0, 'Potential Consortium Member name is required.'),
+});
+
+const memberResponseSchema = z.object({
+  id: z.string().min(1),
+  opportunityId: z.string().min(1),
+  memberName: z.string().min(1),
+  sourceFilename: nullableTextSchema,
+  workbookTitle: nullableTextSchema,
+  importedAt: isoDateTimeSchema,
+  archivedAt: isoDateTimeSchema.nullable(),
+  evaluationState: z.enum(['candidate', 'selected', 'hidden']).nullable(),
+});
+
 const openOpportunityOutputSchema = z.object({
   opportunity: opportunitySchema,
   baseCapabilityMatrix: baseCapabilityMatrixSchema,
@@ -90,6 +144,15 @@ export type ExportBaseCapabilityMatrixIpcInput = z.infer<
 export type ExportBaseCapabilityMatrixIpcOutput = z.infer<
   typeof exportBaseCapabilityMatrixOutputSchema
 >;
+export type MemberResponseImportPreviewDto = z.infer<typeof memberResponseImportPreviewSchema>;
+export type SelectMemberResponseWorkbookForImportIpcInput = z.infer<
+  typeof opportunityIdInputSchema
+>;
+export type SelectMemberResponseWorkbookForImportIpcOutput = z.infer<
+  typeof selectMemberResponseWorkbookForImportOutputSchema
+>;
+export type SaveMemberResponseImportIpcInput = z.infer<typeof saveMemberResponseImportInputSchema>;
+export type MemberResponseDto = z.infer<typeof memberResponseSchema>;
 export type HardDeleteArchivedOpportunityIpcOutput = z.infer<
   typeof hardDeleteArchivedOpportunityOutputSchema
 >;
@@ -141,6 +204,16 @@ export const cmmIpcContracts = {
     channel: 'cmm:base-matrices:export',
     inputSchema: exportBaseCapabilityMatrixInputSchema,
     outputSchema: exportBaseCapabilityMatrixOutputSchema,
+  }),
+  selectMemberResponseWorkbookForImport: defineContract({
+    channel: 'cmm:member-responses:select-import-workbook',
+    inputSchema: opportunityIdInputSchema,
+    outputSchema: selectMemberResponseWorkbookForImportOutputSchema,
+  }),
+  saveMemberResponseImport: defineContract({
+    channel: 'cmm:member-responses:save-import',
+    inputSchema: saveMemberResponseImportInputSchema,
+    outputSchema: memberResponseSchema,
   }),
   archiveOpportunity: defineContract({
     channel: 'cmm:opportunities:archive',

--- a/packages/contracts/src/opportunity-contracts.test.ts
+++ b/packages/contracts/src/opportunity-contracts.test.ts
@@ -41,6 +41,35 @@ const baseCapabilityMatrix = {
   ],
 };
 
+const memberResponseImportPreview = {
+  opportunityId: 'opportunity-1',
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  suggestedMemberName: 'Polar Systems LLC',
+  rows: [
+    {
+      requirementId: 'requirement-1',
+      requirementNumber: '1',
+      requirementText: 'Provide secure hosting',
+      requirementRetiredAt: null,
+      capabilityScore: 3,
+      pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+      responseComment: 'Prime experience\nAvailable immediately',
+    },
+  ],
+};
+
+const memberResponse = {
+  id: 'member-response-1',
+  opportunityId: 'opportunity-1',
+  memberName: 'Polar Systems LLC',
+  sourceFilename: 'Polar Systems response.xlsx',
+  workbookTitle: 'Arctic Radar Upgrade',
+  importedAt: '2026-05-02T11:00:00.000Z',
+  archivedAt: null,
+  evaluationState: 'candidate',
+};
+
 describe('Opportunity IPC contracts', () => {
   it('validates create, list, and open Opportunity IPC payloads', () => {
     expect(cmmIpcContracts.createOpportunity.channel).toBe('cmm:opportunities:create');
@@ -59,6 +88,12 @@ describe('Opportunity IPC contracts', () => {
     );
     expect(cmmIpcContracts.saveBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:save');
     expect(cmmIpcContracts.exportBaseCapabilityMatrix.channel).toBe('cmm:base-matrices:export');
+    expect(cmmIpcContracts.selectMemberResponseWorkbookForImport.channel).toBe(
+      'cmm:member-responses:select-import-workbook',
+    );
+    expect(cmmIpcContracts.saveMemberResponseImport.channel).toBe(
+      'cmm:member-responses:save-import',
+    );
     expect(cmmWindowLifecycleChannels.requestClose).toBe('cmm:window:request-close');
     expect(cmmWindowLifecycleChannels.respondClose).toBe('cmm:window:respond-close');
 
@@ -181,6 +216,69 @@ describe('Opportunity IPC contracts', () => {
         filename: null,
       }),
     ).toThrow();
+    expect(
+      validateIpcInput(cmmIpcContracts.selectMemberResponseWorkbookForImport, {
+        opportunityId: 'opportunity-1',
+      }),
+    ).toEqual({
+      opportunityId: 'opportunity-1',
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.selectMemberResponseWorkbookForImport, {
+        status: 'readyForReview',
+        preview: memberResponseImportPreview,
+      }),
+    ).toEqual({
+      status: 'readyForReview',
+      preview: memberResponseImportPreview,
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.selectMemberResponseWorkbookForImport, {
+        status: 'canceled',
+        preview: null,
+      }),
+    ).toEqual({
+      status: 'canceled',
+      preview: null,
+    });
+    expect(
+      validateIpcOutput(cmmIpcContracts.selectMemberResponseWorkbookForImport, {
+        status: 'rejected',
+        error: { code: 'memberResponse.noUsableRows' },
+        preview: null,
+      }),
+    ).toEqual({
+      status: 'rejected',
+      error: { code: 'memberResponse.noUsableRows' },
+      preview: null,
+    });
+    expect(() =>
+      validateIpcOutput(cmmIpcContracts.selectMemberResponseWorkbookForImport, {
+        status: 'readyForReview',
+        preview: {
+          ...memberResponseImportPreview,
+          rows: [],
+        },
+      }),
+    ).toThrow();
+    expect(
+      validateIpcInput(cmmIpcContracts.saveMemberResponseImport, {
+        ...memberResponseImportPreview,
+        memberName: 'Polar Systems LLC',
+      }),
+    ).toEqual({
+      ...memberResponseImportPreview,
+      memberName: 'Polar Systems LLC',
+    });
+    expect(() =>
+      validateIpcInput(cmmIpcContracts.saveMemberResponseImport, {
+        ...memberResponseImportPreview,
+        memberName: '   ',
+      }),
+    ).toThrow('Potential Consortium Member name is required.');
+    expect(validateIpcOutput(cmmIpcContracts.saveMemberResponseImport, memberResponse)).toEqual(
+      memberResponse,
+    );
     expect(validateIpcOutput(cmmIpcContracts.archiveOpportunity, opportunity)).toEqual(opportunity);
     expect(validateIpcOutput(cmmIpcContracts.restoreArchivedOpportunity, opportunity)).toEqual(
       opportunity,

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,6 +1,8 @@
 export type IsoDateTime = string;
 export type OpportunityId = string;
 export type RequirementId = string;
+export type CapabilityScore = 0 | 1 | 2 | 3;
+export type MemberResponseId = string;
 
 export type Opportunity = {
   id: OpportunityId;
@@ -33,6 +35,31 @@ export type Requirement = {
   level: number;
   position: number;
   retiredAt: IsoDateTime | null;
+};
+
+export type MemberResponseEvaluationState = 'candidate' | 'selected' | 'hidden';
+
+export type MemberResponse = {
+  id: MemberResponseId;
+  opportunityId: OpportunityId;
+  memberName: string;
+  sourceFilename: string | null;
+  workbookTitle: string | null;
+  importedAt: IsoDateTime;
+  archivedAt: IsoDateTime | null;
+  evaluationState: MemberResponseEvaluationState | null;
+};
+
+export type MemberResponseRow = {
+  id: string;
+  memberResponseId: MemberResponseId;
+  requirementId: RequirementId;
+  requirementNumber: string;
+  requirementText: string;
+  capabilityScore: CapabilityScore | null;
+  pastPerformanceReference: string;
+  responseComment: string;
+  position: number;
 };
 
 export type RequirementNumber = {

--- a/packages/persistence-sqlite/src/index.ts
+++ b/packages/persistence-sqlite/src/index.ts
@@ -1,5 +1,15 @@
-import type { OpportunityRepository } from '@cmm/application';
-import type { BaseCapabilityMatrix, Opportunity, OpportunityId, Requirement } from '@cmm/domain';
+import type {
+  OpportunityRepository,
+  SaveActiveMemberResponseRepositoryInput,
+} from '@cmm/application';
+import type {
+  BaseCapabilityMatrix,
+  MemberResponse,
+  MemberResponseRow,
+  Opportunity,
+  OpportunityId,
+  Requirement,
+} from '@cmm/domain';
 import type { Database as SqliteDatabase } from 'better-sqlite3';
 import Database from 'better-sqlite3';
 
@@ -62,6 +72,53 @@ const migrations: Migration[] = [
         ON requirements (opportunity_id, position);
     `,
   },
+  {
+    id: 3,
+    name: '0003_create_member_responses',
+    sql: `
+      CREATE TABLE member_responses (
+        id TEXT PRIMARY KEY,
+        opportunity_id TEXT NOT NULL
+          REFERENCES opportunities(id) ON DELETE CASCADE,
+        member_name TEXT NOT NULL,
+        normalized_member_name TEXT NOT NULL,
+        source_filename TEXT,
+        workbook_title TEXT,
+        imported_at TEXT NOT NULL,
+        archived_at TEXT,
+        evaluation_state TEXT
+          CHECK (
+            evaluation_state IS NULL
+            OR evaluation_state IN ('candidate', 'selected', 'hidden')
+          )
+      );
+
+      CREATE UNIQUE INDEX member_responses_active_member_name_idx
+        ON member_responses (opportunity_id, normalized_member_name)
+        WHERE archived_at IS NULL;
+
+      CREATE INDEX member_responses_opportunity_active_order_idx
+        ON member_responses (opportunity_id, archived_at, imported_at);
+
+      CREATE TABLE member_response_rows (
+        id TEXT PRIMARY KEY,
+        member_response_id TEXT NOT NULL
+          REFERENCES member_responses(id) ON DELETE CASCADE,
+        requirement_id TEXT NOT NULL,
+        requirement_number TEXT NOT NULL,
+        requirement_text TEXT NOT NULL,
+        capability_score INTEGER
+          CHECK (capability_score IS NULL OR capability_score IN (0, 1, 2, 3)),
+        past_performance_reference TEXT NOT NULL,
+        response_comment TEXT NOT NULL,
+        position INTEGER NOT NULL CHECK (position >= 0),
+        UNIQUE (member_response_id, position)
+      );
+
+      CREATE INDEX member_response_rows_response_order_idx
+        ON member_response_rows (member_response_id, position);
+    `,
+  },
 ];
 
 type MigrationRow = {
@@ -94,6 +151,29 @@ type RequirementRow = {
   retired_at: string | null;
 };
 
+type MemberResponseRecordRow = {
+  id: string;
+  opportunity_id: string;
+  member_name: string;
+  source_filename: string | null;
+  workbook_title: string | null;
+  imported_at: string;
+  archived_at: string | null;
+  evaluation_state: 'candidate' | 'selected' | 'hidden' | null;
+};
+
+type MemberResponseRowRecord = {
+  id: string;
+  member_response_id: string;
+  requirement_id: string;
+  requirement_number: string;
+  requirement_text: string;
+  capability_score: 0 | 1 | 2 | 3 | null;
+  past_performance_reference: string;
+  response_comment: string;
+  position: number;
+};
+
 const toOpportunity = (row: OpportunityRow): Opportunity => ({
   id: row.id,
   name: row.name,
@@ -112,6 +192,29 @@ const toRequirement = (row: RequirementRow): Requirement => ({
   level: row.level,
   position: row.position,
   retiredAt: row.retired_at,
+});
+
+const toMemberResponse = (row: MemberResponseRecordRow): MemberResponse => ({
+  id: row.id,
+  opportunityId: row.opportunity_id,
+  memberName: row.member_name,
+  sourceFilename: row.source_filename,
+  workbookTitle: row.workbook_title,
+  importedAt: row.imported_at,
+  archivedAt: row.archived_at,
+  evaluationState: row.evaluation_state,
+});
+
+const toMemberResponseRow = (row: MemberResponseRowRecord): MemberResponseRow => ({
+  id: row.id,
+  memberResponseId: row.member_response_id,
+  requirementId: row.requirement_id,
+  requirementNumber: row.requirement_number,
+  requirementText: row.requirement_text,
+  capabilityScore: row.capability_score,
+  pastPerformanceReference: row.past_performance_reference,
+  responseComment: row.response_comment,
+  position: row.position,
 });
 
 export const runSqliteMigrations = (database: SqliteDatabase): void => {
@@ -321,6 +424,105 @@ export const createSqliteOpportunityRepository = (
     )
   `);
 
+  const listActiveMemberResponses = database.prepare(`
+    SELECT
+      id,
+      opportunity_id,
+      member_name,
+      source_filename,
+      workbook_title,
+      imported_at,
+      archived_at,
+      evaluation_state
+    FROM member_responses
+    WHERE opportunity_id = ? AND archived_at IS NULL
+    ORDER BY imported_at DESC, id ASC
+  `);
+
+  const listMemberResponseRows = database.prepare(`
+    SELECT
+      id,
+      member_response_id,
+      requirement_id,
+      requirement_number,
+      requirement_text,
+      capability_score,
+      past_performance_reference,
+      response_comment,
+      position
+    FROM member_response_rows
+    WHERE member_response_id = ?
+    ORDER BY position ASC
+  `);
+
+  const findMemberResponseById = database.prepare(`
+    SELECT
+      id,
+      opportunity_id,
+      member_name,
+      source_filename,
+      workbook_title,
+      imported_at,
+      archived_at,
+      evaluation_state
+    FROM member_responses
+    WHERE id = ?
+  `);
+
+  const archiveActiveMemberResponses = database.prepare(`
+    UPDATE member_responses
+    SET archived_at = ?, evaluation_state = NULL
+    WHERE opportunity_id = ? AND normalized_member_name = ? AND archived_at IS NULL
+  `);
+
+  const insertMemberResponse = database.prepare(`
+    INSERT INTO member_responses (
+      id,
+      opportunity_id,
+      member_name,
+      normalized_member_name,
+      source_filename,
+      workbook_title,
+      imported_at,
+      archived_at,
+      evaluation_state
+    ) VALUES (
+      @id,
+      @opportunityId,
+      @memberName,
+      @normalizedMemberName,
+      @sourceFilename,
+      @workbookTitle,
+      @importedAt,
+      @archivedAt,
+      @evaluationState
+    )
+  `);
+
+  const insertMemberResponseRow = database.prepare(`
+    INSERT INTO member_response_rows (
+      id,
+      member_response_id,
+      requirement_id,
+      requirement_number,
+      requirement_text,
+      capability_score,
+      past_performance_reference,
+      response_comment,
+      position
+    ) VALUES (
+      @id,
+      @memberResponseId,
+      @requirementId,
+      @requirementNumber,
+      @requirementText,
+      @capabilityScore,
+      @pastPerformanceReference,
+      @responseComment,
+      @position
+    )
+  `);
+
   const loadMatrix = (opportunityId: OpportunityId): BaseCapabilityMatrix => {
     const matrixRow = findBaseCapabilityMatrix.get(opportunityId) as
       | BaseCapabilityMatrixRow
@@ -369,6 +571,29 @@ export const createSqliteOpportunityRepository = (
 
     return loadMatrix(matrix.opportunityId);
   });
+
+  const saveActiveMemberResponse = database.transaction(
+    (input: SaveActiveMemberResponseRepositoryInput) => {
+      archiveActiveMemberResponses.run(
+        input.archivedAt,
+        input.memberResponse.opportunityId,
+        input.normalizedMemberName,
+      );
+      insertMemberResponse.run({
+        ...input.memberResponse,
+        normalizedMemberName: input.normalizedMemberName,
+      });
+      for (const row of input.rows) {
+        insertMemberResponseRow.run(row);
+      }
+
+      const row = findMemberResponseById.get(input.memberResponse.id);
+      if (!row) {
+        throw new Error('Member Response not found after save.');
+      }
+      return toMemberResponse(row as MemberResponseRecordRow);
+    },
+  );
 
   return {
     async saveOpportunity(opportunity) {
@@ -433,6 +658,22 @@ export const createSqliteOpportunityRepository = (
 
     async saveBaseCapabilityMatrix(matrix) {
       return saveMatrix(matrix);
+    },
+
+    async listActiveMemberResponses(opportunityId) {
+      return listActiveMemberResponses
+        .all(opportunityId)
+        .map((row) => toMemberResponse(row as MemberResponseRecordRow));
+    },
+
+    async loadMemberResponseRows(memberResponseId) {
+      return listMemberResponseRows
+        .all(memberResponseId)
+        .map((row) => toMemberResponseRow(row as MemberResponseRowRecord));
+    },
+
+    async saveActiveMemberResponse(input) {
+      return saveActiveMemberResponse(input);
     },
   };
 };

--- a/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
+++ b/packages/persistence-sqlite/src/sqlite-opportunity-repository.test.ts
@@ -189,6 +189,96 @@ describe('SQLite Opportunity repository', () => {
     secondDatabase.close();
   });
 
+  it('persists active Member Responses with plain text line breaks across database connections', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-member-responses-'));
+    tempDirs.push(dir);
+    const databasePath = path.join(dir, 'cmm.sqlite');
+
+    const firstDatabase = createCmmSqliteDatabase(databasePath);
+    const firstRepository = createSqliteOpportunityRepository(firstDatabase);
+    const idValues = ['opportunity-1', 'member-response-1', 'member-response-row-1'];
+    const firstService = createOpportunityService({
+      repository: firstRepository,
+      clock: createClock(['2026-05-01T09:00:00.000Z', '2026-05-02T11:00:00.000Z']),
+      ids: {
+        next: () => {
+          const id = idValues.shift();
+          if (!id) {
+            throw new Error('No ID configured for test.');
+          }
+          return id;
+        },
+      },
+    });
+
+    const opportunity = await firstService.createOpportunity({
+      name: 'Maritime Logistics Support',
+    });
+    await firstService.saveBaseCapabilityMatrix({
+      opportunityId: opportunity.id,
+      revision: 0,
+      requirements: [
+        {
+          id: 'requirement-1',
+          text: 'Provide secure hosting',
+          level: 1,
+          position: 0,
+          retiredAt: null,
+        },
+      ],
+    });
+    const preview = await firstService.previewMemberResponseImport({
+      opportunityId: opportunity.id,
+      sourceFilename: 'Polar Systems response.xlsx',
+      parsedWorkbook: {
+        metadata: {
+          workbookFormatVersion: '1',
+          opportunityId: opportunity.id,
+          exportTimestamp: '2026-05-02T10:00:00.000Z',
+        },
+        workbookTitle: 'Maritime Logistics Support',
+        memberName: 'Polar Systems LLC',
+        rows: [
+          {
+            requirementId: 'requirement-1',
+            requirementNumber: '1',
+            requirementText: 'Provide secure hosting',
+            capabilityScore: 3,
+            pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+            responseComment: 'Prime experience\nAvailable immediately',
+          },
+        ],
+      },
+    });
+
+    const saved = await firstService.saveMemberResponseImport({
+      ...preview,
+      memberName: preview.suggestedMemberName,
+    });
+    firstDatabase.close();
+
+    const secondDatabase = createCmmSqliteDatabase(databasePath);
+    const secondRepository = createSqliteOpportunityRepository(secondDatabase);
+
+    await expect(secondRepository.listActiveMemberResponses(opportunity.id)).resolves.toEqual([
+      saved,
+    ]);
+    await expect(secondRepository.loadMemberResponseRows(saved.id)).resolves.toEqual([
+      {
+        id: 'member-response-row-1',
+        memberResponseId: saved.id,
+        requirementId: 'requirement-1',
+        requirementNumber: '1',
+        requirementText: 'Provide secure hosting',
+        capabilityScore: 3,
+        pastPerformanceReference: 'Hosted IL5 workloads\nSupported SOC operations',
+        responseComment: 'Prime experience\nAvailable immediately',
+        position: 0,
+      },
+    ]);
+    secondDatabase.close();
+  });
+
   it('removes hard-deleted archived Opportunities across database connections', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'cmm-sqlite-opportunities-'));
     tempDirs.push(dir);

--- a/packages/workbook/src/base-capability-matrix-workbook.test.ts
+++ b/packages/workbook/src/base-capability-matrix-workbook.test.ts
@@ -163,6 +163,7 @@ describe('Base Capability Matrix workbook export', () => {
         opportunityId: 'opportunity-1',
         exportTimestamp: '2026-05-02T10:00:00.000Z',
       },
+      workbookTitle: 'Arctic Radar Upgrade',
       memberName: 'Polar Systems LLC',
       rows: [
         {

--- a/packages/workbook/src/index.ts
+++ b/packages/workbook/src/index.ts
@@ -31,6 +31,7 @@ export type ParsedMemberResponseWorkbook = {
     opportunityId: string;
     exportTimestamp: IsoDateTime;
   };
+  workbookTitle: string;
   memberName: string;
   rows: {
     requirementId: string;
@@ -106,6 +107,7 @@ export const parseMemberResponseWorkbook = async (
       opportunityId: cellValueToText(metadataSheet.getCell('B2').value),
       exportTimestamp: cellValueToText(metadataSheet.getCell('B3').value),
     },
+    workbookTitle: cellValueToText(matrixSheet.getCell('B1').value),
     memberName: cellValueToText(matrixSheet.getCell('B4').value),
     rows,
   };


### PR DESCRIPTION
## Summary

- Add clean Member Response import preview and save flow across workbook parsing, application service, SQLite persistence, typed IPC, and renderer review UI.
- Use main-owned file dialog and workbook byte parsing for returned CMM-authored workbooks.
- Persist active Member Responses and response rows, including plain text line breaks, with no original workbook storage.
- Surface no-usable-row imports as a typed expected recovery state.

## Validation

- `pnpm --filter=@cmm/application test -- --runInBand`
- `pnpm --filter=@cmm/persistence-sqlite test -- --runInBand`
- `pnpm --filter=@cmm/workbook test -- --runInBand`
- `pnpm --filter=@cmm/contracts test -- --runInBand`
- `pnpm --filter=@app/desktop test:unit -- --runInBand`
- `pnpm check`
- `pnpm --filter=@app/desktop test:e2e`
- pre-commit `format`, `lint`, `check`, and `typecheck`

Closes #13
